### PR TITLE
reduced error overlay z-index

### DIFF
--- a/src/components/ErrorOverlay.tsx
+++ b/src/components/ErrorOverlay.tsx
@@ -119,7 +119,7 @@ export const ErrorOverlay = ({ children, transform, elements }: Props) => {
               <div
                 className={css`
                   position: absolute;
-                  z-index: 1000;
+                  z-index: 100;
                   left: ${errorCenter.x}px;
                   top: ${errorCenter.y}px;
                   color: red;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3a6f9611-178d-408f-b5fe-0bc06988dbf8)
The export dialog has a z-index of 101 so I reduced it for the error overlay to 100 