### PR TITLE
Revert "Convert children rendering to core" (broke pcb viewer bounds computation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,12 @@
     "@storybook/nextjs": "^8.0.6",
     "@storybook/react": "^8.0.6",
     "@swc/core": "^1.4.12",
-    "@tscircuit/core": "^0.0.106",
+    "@tscircuit/builder": "^1.11.4",
+    "@tscircuit/core": "^0.0.88",
     "@tscircuit/eagle-xml-converter": "^0.0.6",
     "@tscircuit/props": "^0.0.46",
-    "@tscircuit/soup-util": "^0.0.32",
+    "@tscircuit/react-fiber": "^1.1.25",
+    "@tscircuit/soup-util": "^0.0.13",
     "@types/color": "^3.0.6",
     "@types/node": "18.7.23",
     "@types/react": "^18.3.3",
@@ -43,8 +45,9 @@
     "zod": "^3.23.5"
   },
   "peerDependencies": {
-    "react": "*",
-    "@tscircuit/core": "*"
+    "@tscircuit/builder": "*",
+    "@tscircuit/react-fiber": "*",
+    "react": "*"
   },
   "dependencies": {
     "@emotion/css": "^11.11.2",

--- a/src/PCBViewer.tsx
+++ b/src/PCBViewer.tsx
@@ -1,17 +1,19 @@
 import React, { useEffect, useMemo, useState } from "react"
+import { createRoot } from "@tscircuit/react-fiber"
+import { createProjectBuilder } from "@tscircuit/builder"
 import type { AnyCircuitElement } from "circuit-json"
 import { CanvasElementsRenderer } from "./components/CanvasElementsRenderer"
 import useMouseMatrixTransform from "use-mouse-matrix-transform"
 import { useMeasure } from "react-use"
 import { compose, scale, translate } from "transformation-matrix"
-import { getBoundsOfPcbElements } from "@tscircuit/soup-util"
+import { findBoundsAndCenter } from "@tscircuit/builder"
 import { ContextProviders } from "components/ContextProviders"
 import type { EditEvent } from "lib/edit-events"
 import { applyEditEvents } from "lib/apply-edit-events"
 import { RatsNestOverlay } from "./components/RatsNestOverlay"
 import type { StateProps } from "global-store"
 import { ToastContainer } from "lib/toast"
-import { useRenderedCircuit } from "@tscircuit/core"
+
 const defaultTransform = compose(translate(400, 300), scale(40, -40))
 
 type Props = {
@@ -33,10 +35,7 @@ export const PCBViewer = ({
   editEvents: editEventsProp,
   onEditEventsChanged,
 }: Props) => {
-  const { circuitJson: circuitJsonFromChildren, error: errorFromChildren } =
-    useRenderedCircuit(children)
-  const stateElements = circuitJsonFromChildren ?? soup ?? []
-
+  const [stateElements, setStateElements] = useState<Array<AnyCircuitElement>>([])
   const [ref, refDimensions] = useMeasure()
   const [transform, setTransformInternal] = useState(defaultTransform)
   const {
@@ -50,27 +49,18 @@ export const PCBViewer = ({
   let [editEvents, setEditEvents] = useState<EditEvent[]>([])
   editEvents = editEventsProp ?? editEvents
 
-  const [error, setError] = useState<string | null>(null)
-
-  useEffect(() => {
-    setError(errorFromChildren ? errorFromChildren.toString() : null)
-  }, [errorFromChildren])
+  const [error, setError] = useState(null)
 
   const resetTransform = () => {
     const elmBounds =
       refDimensions?.width > 0 ? refDimensions : { width: 500, height: 500 }
-    const { minX, minY, maxX, maxY } = elements.some((e) =>
+    const { center, width, height } = elements.some((e) =>
       e.type.startsWith("pcb_"),
     )
-      ? getBoundsOfPcbElements(
-          elements.filter((e) => e.type.startsWith("pcb_")) as any,
-        )
-      : { minX: -0.001, minY: -0.001, maxX: 0.001, maxY: 0.001 }
-
-    const width = maxX - minX
-    const height = maxY - minY
-    const center = { x: (minX + maxX) / 2, y: (minY + maxY) / 2 }
-
+      ? findBoundsAndCenter(
+        elements.filter((e) => e.type.startsWith("pcb_")) as any,
+      )
+      : { center: { x: 0, y: 0 }, width: 0.001, height: 0.001 }
     const scaleFactor =
       Math.min(
         (elmBounds.width ?? 0) / width,
@@ -86,6 +76,24 @@ export const PCBViewer = ({
       ),
     )
   }
+
+  useEffect(() => {
+    if (!children || children?.length === 0) return
+    async function doRender() {
+      // TODO re-use project builder
+      const projectBuilder = createProjectBuilder()
+      await createRoot()
+        .render(children, projectBuilder as any)
+        .then((elements) => {
+          setStateElements(elements as any)
+          setError(null)
+        })
+    }
+    doRender().catch((e) => {
+      setError(e.toString())
+      console.log(e.toString())
+    })
+  }, [children])
 
   useEffect(() => {
     if (refDimensions && refDimensions.width !== 0 && (children || soup)) {

--- a/src/stories/simple-resistor.stories.tsx
+++ b/src/stories/simple-resistor.stories.tsx
@@ -5,9 +5,7 @@ export const SimpleResistorSMD = () => {
   return (
     <div style={{ backgroundColor: "black" }}>
       <PCBViewer>
-        <board width="10mm" height="10mm">
-          <resistor name="R1" footprint="0805" resistance="10k" />
-        </board>
+        <resistor name="R1" footprint="0805" resistance="10k" />
       </PCBViewer>
     </div>
   )
@@ -17,9 +15,12 @@ export const SimpleResistorThruHole = () => {
   return (
     <div style={{ backgroundColor: "black" }}>
       <PCBViewer>
-        <board width="10mm" height="10mm">
-          <resistor name="R1" footprint="axial" resistance="10k" />
-        </board>
+        {/* <resistor footprint="dip" resistance="10k" /> */}
+        {/* TODO use resistor with some kind of through hole footprint name */}
+        <component name="R1">
+          <platedhole shape="circle" pcbX={0} pcbY={0} holeDiameter="1mm" outerDiameter="2mm" />
+          <platedhole shape="circle" pcbX={6} pcbY={0} holeDiameter="1mm" outerDiameter="2mm" />
+        </component>
       </PCBViewer>
     </div>
   )
@@ -29,15 +30,13 @@ export const SimpleResistorsOffCenter = () => {
   return (
     <div style={{ backgroundColor: "black" }}>
       <PCBViewer>
-        <board width="10mm" height="10mm">
-          <resistor
-            name="R1"
-            footprint="0805"
-            resistance="10k"
-            pcbX={5}
-            pcbY={5}
-          />
-        </board>
+        <resistor
+          name="R1"
+          footprint="0805"
+          resistance="10k"
+          pcbX={5}
+          pcbY={5}
+        />
         {/* <resistor
           name="R2"
           footprint="0805"


### PR DESCRIPTION
Reverts tscircuit/pcb-viewer#70

There is some issue with the bounds computation