### PR TITLE
feat: disable "mouse hover focuses PCB viewer" by default

### DIFF
--- a/src/PCBViewer.tsx
+++ b/src/PCBViewer.tsx
@@ -23,6 +23,7 @@ type Props = {
   editEvents?: EditEvent[]
   initialState?: Partial<StateProps>
   onEditEventsChanged?: (editEvents: EditEvent[]) => void
+  focusOnHover?: boolean
 }
 
 export const PCBViewer = ({
@@ -34,6 +35,7 @@ export const PCBViewer = ({
   allowEditing = true,
   editEvents: editEventsProp,
   onEditEventsChanged,
+  focusOnHover = false,
 }: Props) => {
   circuitJson ??= soup
   const {
@@ -123,6 +125,7 @@ export const PCBViewer = ({
             height={height}
             width={refDimensions.width}
             allowEditing={allowEditing}
+            focusOnHover={focusOnHover}
             cancelPanDrag={cancelPanDrag}
             onCreateEditEvent={onCreateEditEvent}
             onModifyEditEvent={onModifyEditEvent}

--- a/src/components/CanvasElementsRenderer.tsx
+++ b/src/components/CanvasElementsRenderer.tsx
@@ -23,6 +23,7 @@ export interface CanvasElementsRendererProps {
   height?: number
   grid?: GridConfig
   allowEditing: boolean
+  focusOnHover: boolean
   cancelPanDrag: Function
   onCreateEditEvent: (event: EditEvent) => void
   onModifyEditEvent: (event: Partial<EditEvent>) => void
@@ -50,6 +51,7 @@ export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
       elements={elements}
       transform={transform}
       primitives={primitivesWithoutInteractionMetadata}
+      focusOnHover={props.focusOnHover}
       onMouseHoverOverPrimitives={(primitivesHoveredOver) => {
         const primitiveIdsInMousedOverNet: string[] = []
         for (const primitive of primitivesHoveredOver) {

--- a/src/components/MouseElementTracker.tsx
+++ b/src/components/MouseElementTracker.tsx
@@ -12,12 +12,14 @@ export const MouseElementTracker = ({
   children,
   transform,
   primitives,
+  focusOnHover,
   onMouseHoverOverPrimitives,
 }: {
   elements: AnyCircuitElement[]
   children: any
   transform?: Matrix
   primitives: Primitive[]
+  focusOnHover: boolean
   onMouseHoverOverPrimitives: (primitivesHoveredOver: Primitive[]) => void
 }) => {
   const [mousedPrimitives, setMousedPrimitives] = useState<Primitive[]>([])
@@ -115,6 +117,14 @@ export const MouseElementTracker = ({
             ) {
               newMousedPrimitives.push(primitive)
             }
+          }
+
+          if (!focusOnHover) {
+            if (mousedPrimitives.length > 0) {
+              setMousedPrimitives([])
+              onMouseHoverOverPrimitives([])
+            }
+            return
           }
 
           if (


### PR DESCRIPTION

- The default behavior for mouse hover focusing the PCB viewer has been disabled.
- Added a new `focusOnHover` prop to allow enabling this feature if required.

/claim #139
Fixes #139 