### PR TITLE
fix: improve bottom silkscreen visibility with distinct color

### DIFF
--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -20,7 +20,7 @@ export default {
     b_fab: "rgb(88, 93, 132)",
     b_mask: "rgba(2, 255, 238, 0.400)",
     b_paste: "rgb(0, 194, 194)",
-    b_silks: "rgb(94, 153, 230)",
+    b_silks: "rgb(242, 237, 161)",
     background: "rgb(0, 16, 35)",
     cmts_user: "rgb(89, 148, 220)",
     copper: {


### PR DESCRIPTION
## Description
This change enhances the visibility of bottom layer silkscreen by changing its color from blue to yellow. The previous color was too similar to the blue copper traces, making it difficult to distinguish between traces and silkscreen markings.

## Changes Made
- Updated `b_silks` color in `colors.ts` from `rgb(94, 153, 230)` to `rgb(242, 237, 161)`

## Related Issues
Issue #198

claim #198 