### PR TITLE
fix: transform state going back to default

### DIFF
--- a/src/PCBViewer.tsx
+++ b/src/PCBViewer.tsx
@@ -71,7 +71,7 @@ export const PCBViewer = ({
   editEvents = editEventsProp ?? editEvents
 
   const initialRenderCompleted = useRef(false)
-  const circuitJsonKey = `${circuitJson?.length || 0}_${JSON.stringify(circuitJson)}`
+  const circuitJsonKey = `${circuitJson?.length || 0}_${Math.random()}`
 
   const resetTransform = (shouldAnimate = false) => {
     const elmBounds =

--- a/src/PCBViewer.tsx
+++ b/src/PCBViewer.tsx
@@ -3,15 +3,15 @@ import { findBoundsAndCenter } from "@tscircuit/soup-util"
 import type { AnyCircuitElement } from "circuit-json"
 import { ContextProviders } from "components/ContextProviders"
 import type { StateProps } from "global-store"
+import type { GraphicsObject } from "graphics-debug"
 import { applyEditEvents } from "lib/apply-edit-events"
 import type { EditEvent } from "lib/edit-events"
 import { ToastContainer } from "lib/toast"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { useMeasure } from "react-use"
 import { compose, scale, translate } from "transformation-matrix"
 import useMouseMatrixTransform from "use-mouse-matrix-transform"
 import { CanvasElementsRenderer } from "./components/CanvasElementsRenderer"
-import type { GraphicsObject } from "graphics-debug"
 
 const defaultTransform = compose(translate(400, 300), scale(40, -40))
 
@@ -70,7 +70,10 @@ export const PCBViewer = ({
   let [editEvents, setEditEvents] = useState<EditEvent[]>([])
   editEvents = editEventsProp ?? editEvents
 
-  const resetTransform = (shouldAnimate: boolean = false) => {
+  const initialRenderCompleted = useRef(false)
+  const circuitJsonKey = `${circuitJson?.length || 0}_${JSON.stringify(circuitJson)}`
+
+  const resetTransform = (shouldAnimate = false) => {
     const elmBounds =
       refDimensions?.width > 0 ? refDimensions : { width: 500, height: 500 }
     const { center, width, height } = elements.some((e) =>
@@ -145,7 +148,10 @@ export const PCBViewer = ({
     if (!(children || soup || circuitJson)) return
     if (clickToInteractEnabled && !isInteractionEnabled) return
 
-    resetTransform(false) // No animation for initial/component updates
+    if (!initialRenderCompleted.current) {
+      resetTransform(false)
+      initialRenderCompleted.current = true
+    }
   }, [
     children,
     circuitJson,
@@ -155,13 +161,13 @@ export const PCBViewer = ({
     disableAutoFocus,
   ])
 
-  const pcbElmsPreEdit: AnyCircuitElement[] = useMemo(
-    () =>
+  const pcbElmsPreEdit = useMemo(() => {
+    return (
       circuitJson?.filter(
         (e: any) => e.type.startsWith("pcb_") || e.type.startsWith("source_"),
-      ) ?? [],
-    [circuitJson],
-  )
+      ) ?? []
+    )
+  }, [circuitJsonKey])
 
   const elements = useMemo(() => {
     return applyEditEvents(pcbElmsPreEdit, editEvents)

--- a/src/components/CanvasElementsRenderer.tsx
+++ b/src/components/CanvasElementsRenderer.tsx
@@ -1,22 +1,21 @@
-import React, { useCallback, useState } from "react"
-import { CanvasPrimitiveRenderer } from "./CanvasPrimitiveRenderer"
-import { pcb_port, type AnyCircuitElement } from "circuit-json"
-import { useMemo } from "react"
-import { convertElementToPrimitives } from "../lib/convert-element-to-primitive"
-import type { Matrix } from "transformation-matrix"
-import type { GridConfig, Primitive } from "lib/types"
-import { MouseElementTracker } from "./MouseElementTracker"
-import { DimensionOverlay } from "./DimensionOverlay"
-import { ToolbarOverlay } from "./ToolbarOverlay"
-import { ErrorOverlay } from "./ErrorOverlay"
-import { EditPlacementOverlay } from "./EditPlacementOverlay"
-import type { EditEvent } from "lib/edit-events"
-import { EditTraceHintOverlay } from "./EditTraceHintOverlay"
-import { RatsNestOverlay } from "./RatsNestOverlay"
+import type { AnyCircuitElement } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
-import { addInteractionMetadataToPrimitives } from "lib/util/addInteractionMetadataToPrimitives"
-import { DebugGraphicsOverlay } from "./DebugGraphicsOverlay"
 import type { GraphicsObject } from "graphics-debug"
+import type { EditEvent } from "lib/edit-events"
+import type { GridConfig, Primitive } from "lib/types"
+import { addInteractionMetadataToPrimitives } from "lib/util/addInteractionMetadataToPrimitives"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import type { Matrix } from "transformation-matrix"
+import { convertElementToPrimitives } from "../lib/convert-element-to-primitive"
+import { CanvasPrimitiveRenderer } from "./CanvasPrimitiveRenderer"
+import { DebugGraphicsOverlay } from "./DebugGraphicsOverlay"
+import { DimensionOverlay } from "./DimensionOverlay"
+import { EditPlacementOverlay } from "./EditPlacementOverlay"
+import { EditTraceHintOverlay } from "./EditTraceHintOverlay"
+import { ErrorOverlay } from "./ErrorOverlay"
+import { MouseElementTracker } from "./MouseElementTracker"
+import { RatsNestOverlay } from "./RatsNestOverlay"
+import { ToolbarOverlay } from "./ToolbarOverlay"
 
 export interface CanvasElementsRendererProps {
   elements: AnyCircuitElement[]
@@ -80,6 +79,16 @@ export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
     },
     [primitives],
   )
+
+  useEffect(() => {
+    const newPrimitives = addInteractionMetadataToPrimitives({
+      primitivesWithoutInteractionMetadata,
+      drawingObjectIdsWithMouseOver: new Set(),
+      primitiveIdsInMousedOverNet: [],
+    })
+
+    setPrimitives(newPrimitives)
+  }, [props.elements, primitivesWithoutInteractionMetadata])
 
   return (
     <MouseElementTracker

--- a/src/components/CanvasElementsRenderer.tsx
+++ b/src/components/CanvasElementsRenderer.tsx
@@ -4,7 +4,7 @@ import type { GraphicsObject } from "graphics-debug"
 import type { EditEvent } from "lib/edit-events"
 import type { GridConfig, Primitive } from "lib/types"
 import { addInteractionMetadataToPrimitives } from "lib/util/addInteractionMetadataToPrimitives"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useMemo, useState } from "react"
 import type { Matrix } from "transformation-matrix"
 import { convertElementToPrimitives } from "../lib/convert-element-to-primitive"
 import { CanvasPrimitiveRenderer } from "./CanvasPrimitiveRenderer"
@@ -44,51 +44,45 @@ export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
       return [primitivesWithoutInteractionMetadata, connectivityMap]
     }, [props.elements])
 
-  const [primitives, setPrimitives] = useState<Primitive[]>(
-    primitivesWithoutInteractionMetadata,
-  )
+  const [hoverState, setHoverState] = useState({
+    drawingObjectIdsWithMouseOver: new Set<string>(),
+    primitiveIdsInMousedOverNet: [] as string[]
+  });
 
-  const onMouseOverPrimitives = useCallback(
-    (primitivesHoveredOver: Primitive[]) => {
-      const primitiveIdsInMousedOverNet: string[] = []
-      for (const primitive of primitivesHoveredOver) {
-        if (primitive._element) {
-          const connectedPrimitivesList = connectivityMap.getNetConnectedToId(
-            "pcb_port_id" in primitive._element
-              ? primitive._element?.pcb_port_id!
-              : "pcb_trace_id" in primitive._element
-                ? primitive._element?.pcb_trace_id!
-                : "",
-          )
-          primitiveIdsInMousedOverNet.push(
-            ...connectivityMap.getIdsConnectedToNet(connectedPrimitivesList!),
-          )
-        }
-      }
-
-      const drawingObjectIdsWithMouseOver = new Set(
-        primitivesHoveredOver.map((p) => p._pcb_drawing_object_id),
-      )
-      const newPrimitives = addInteractionMetadataToPrimitives({
-        primitivesWithoutInteractionMetadata,
-        drawingObjectIdsWithMouseOver,
-        primitiveIdsInMousedOverNet,
-      })
-
-      setPrimitives(newPrimitives)
-    },
-    [primitives],
-  )
-
-  useEffect(() => {
-    const newPrimitives = addInteractionMetadataToPrimitives({
+  const primitives = useMemo(() => {
+    return addInteractionMetadataToPrimitives({
       primitivesWithoutInteractionMetadata,
-      drawingObjectIdsWithMouseOver: new Set(),
-      primitiveIdsInMousedOverNet: [],
-    })
+      drawingObjectIdsWithMouseOver: hoverState.drawingObjectIdsWithMouseOver,
+      primitiveIdsInMousedOverNet: hoverState.primitiveIdsInMousedOverNet,
+    });
+  }, [primitivesWithoutInteractionMetadata, hoverState]);
 
-    setPrimitives(newPrimitives)
-  }, [props.elements, primitivesWithoutInteractionMetadata])
+  const onMouseOverPrimitives = useCallback((primitivesHoveredOver: Primitive[]) => {
+    const primitiveIdsInMousedOverNet: string[] = []
+    for (const primitive of primitivesHoveredOver) {
+      if (primitive._element) {
+        const connectedPrimitivesList = connectivityMap.getNetConnectedToId(
+          "pcb_port_id" in primitive._element
+            ? primitive._element?.pcb_port_id!
+            : "pcb_trace_id" in primitive._element
+              ? primitive._element?.pcb_trace_id!
+              : "",
+        )
+        primitiveIdsInMousedOverNet.push(
+          ...connectivityMap.getIdsConnectedToNet(connectedPrimitivesList!),
+        )
+      }
+    }
+
+    const drawingObjectIdsWithMouseOver = new Set(
+      primitivesHoveredOver.map((p) => p._pcb_drawing_object_id),
+    )
+
+    setHoverState({
+      drawingObjectIdsWithMouseOver,
+      primitiveIdsInMousedOverNet
+    });
+  }, [connectivityMap]);
 
   return (
     <MouseElementTracker

--- a/src/stories/transform-on-update.stories.tsx
+++ b/src/stories/transform-on-update.stories.tsx
@@ -1,0 +1,66 @@
+import { useState } from "react";
+import { PCBViewer } from "../PCBViewer";
+
+// Create a test component that maintains PCBViewer instance while updating circuit
+const PCBViewerTransformTest = () => {
+  // Initial circuit with a single resistor
+  const [circuit, setCircuit] = useState([
+    { type: "pcb_component", pcb_component_id: "r1", x: 0, y: 0 },
+    { type: "pcb_smtpad", pcb_component_id: "r1", shape: "rect", x: -1, y: 0, width: 0.8, height: 1.2 },
+    { type: "pcb_smtpad", pcb_component_id: "r1", shape: "rect", x: 1, y: 0, width: 0.8, height: 1.2 }
+  ]);
+  
+  // Track update count for debugging
+  const [updateCount, setUpdateCount] = useState(0);
+  
+  // Add components to the right
+  const addComponent = () => {
+    const newX = updateCount * 5; // Place each new component 5 units to the right
+    setCircuit(prev => [
+      ...prev,
+      { type: "pcb_component", pcb_component_id: `r${updateCount+2}`, x: newX, y: 0 },
+      { type: "pcb_smtpad", pcb_component_id: `r${updateCount+2}`, shape: "rect", x: newX-1, y: 0, width: 0.8, height: 1.2 },
+      { type: "pcb_smtpad", pcb_component_id: `r${updateCount+2}`, shape: "rect", x: newX+1, y: 0, width: 0.8, height: 1.2 }
+    ]);
+    console.log(circuit, "circuit")
+    setUpdateCount(c => c + 1);
+  };
+  
+  // Check if circuitJson data is properly updating
+  const componentCount = circuit.filter(c => c.type === "pcb_component").length;
+  
+  return (
+    <div>
+      <div style={{ padding: "10px", background: "#f0f0f0", marginBottom: "10px" }}>
+        <h2>PCBViewer Transform Test</h2>
+        <p>Components: {componentCount} | Updates: {updateCount}</p>
+        <p>If working correctly, the view transform (zoom/pan) should NOT reset when adding components</p>
+        <button 
+          onClick={addComponent}
+          style={{ padding: "8px 16px", background: "#4CAF50", color: "white", border: "none", borderRadius: "4px", cursor: "pointer" }}
+        >
+          Add Component
+        </button>
+        <p style={{ fontSize: "13px", opacity: 0.8 }}>
+          1. Pan/zoom the view to a position you like<br/>
+          2. Click the button to add a component<br/>
+          3. If the view position stays the same, it's working!
+        </p>
+      </div>
+      
+      <div style={{ height: "500px", border: "1px solid #ddd" }}>
+        <PCBViewer 
+          circuitJson={circuit}
+          height={500}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default {
+    title: 'Tests/PCBViewer Transform',
+    component: PCBViewerTransformTest,
+  };
+  
+  export const TransformTest = () => <PCBViewerTransformTest />;

--- a/src/stories/transform-on-update.stories.tsx
+++ b/src/stories/transform-on-update.stories.tsx
@@ -50,7 +50,7 @@ const PCBViewerTransformTest = () => {
       
       <div style={{ height: "500px", border: "1px solid #ddd" }}>
         <PCBViewer 
-          circuitJson={circuit}
+          soup={circuit}
           height={500}
         />
       </div>


### PR DESCRIPTION
- Adding the effect in the CanvasElementsRenderer because the primitives only get the initial vales and meta data is necessary for drawing.

- circuitJsonKey is used as dependency, also the hidden values of circuitJson is not passed as props to this (Not sure using the full circuitJson as key is a good thing, we can replace it)