### PR TITLE
remove random factor in key

### DIFF
--- a/src/PCBViewer.tsx
+++ b/src/PCBViewer.tsx
@@ -71,7 +71,7 @@ export const PCBViewer = ({
   editEvents = editEventsProp ?? editEvents
 
   const initialRenderCompleted = useRef(false)
-  const circuitJsonKey = `${circuitJson?.length || 0}_${Math.random()}`
+  const circuitJsonKey = `${circuitJson?.length || 0}`
 
   const resetTransform = (shouldAnimate = false) => {
     const elmBounds =


### PR DESCRIPTION
CC @imrishabh18 i noticed this was inserted after review, this caused all memoization optimizations to not work and defeated the purpose of the key entirely.

The key in React needs to stay consistent across re-renders (the purpose of the key is to indicate if a re-render is necessary, every time it changes it causes an expensive rerender)