### PR TITLE
fix: adjust layer rendering order to ensure components appear on top

### DIFF
--- a/src/components/CanvasPrimitiveRenderer.tsx
+++ b/src/components/CanvasPrimitiveRenderer.tsx
@@ -18,6 +18,7 @@ interface Props {
 }
 
 const orderedLayers = [
+  "board",
   "bottom_silkscreen",
   "bottom",
   "top",

--- a/src/lib/Drawer.ts
+++ b/src/lib/Drawer.ts
@@ -59,6 +59,7 @@ export const LAYER_NAME_TO_COLOR = {
 export type LayerNameForColor = keyof typeof LAYER_NAME_TO_COLOR
 
 export const DEFAULT_DRAW_ORDER = [
+  "board",
   "top",
   "top_silkscreen",
   "bottom_silkscreen",


### PR DESCRIPTION
/claim #241 

![Screenshot 2025-04-24 210657](https://github.com/user-attachments/assets/4190bc07-b579-49cc-8970-017768301a9c)

