### PR TITLE
Add measure tool button

### DIFF
--- a/src/components/DimensionOverlay.tsx
+++ b/src/components/DimensionOverlay.tsx
@@ -18,6 +18,13 @@ export const DimensionOverlay = ({
   const [dimensionToolVisible, setDimensionToolVisible] = useState(false)
   const [dimensionToolStretching, setDimensionToolStretching] = useState(false)
   const [measureToolArmed, setMeasureToolArmed] = useState(false)
+
+  const disarmMeasure = () => {
+    if (measureToolArmed) {
+      setMeasureToolArmed(false)
+      window.dispatchEvent(new Event("disarm-dimension-tool"))
+    }
+  }
   // Start of dimension tool line in real-world coordinates (not screen)
   const [dStart, setDStart] = useState({ x: 0, y: 0 })
   // End of dimension tool line in real-world coordinates (not screen)
@@ -35,10 +42,12 @@ export const DimensionOverlay = ({
         setDEnd({ x: mousePosRef.current.x, y: mousePosRef.current.y })
         setDimensionToolVisible((visible: boolean) => !visible)
         setDimensionToolStretching(true)
+        disarmMeasure()
       }
       if (e.key === "Escape") {
         setDimensionToolVisible(false)
         setDimensionToolStretching(false)
+        disarmMeasure()
       }
     }
 
@@ -67,6 +76,7 @@ export const DimensionOverlay = ({
     }
     return () => {
       window.removeEventListener("arm-dimension-tool", armMeasure)
+      disarmMeasure()
       if (container) {
         container.removeEventListener("focus", addKeyListener)
         container.removeEventListener("blur", removeKeyListener)
@@ -131,7 +141,7 @@ export const DimensionOverlay = ({
           setDEnd({ x: rwPoint.x, y: rwPoint.y })
           setDimensionToolVisible(true)
           setDimensionToolStretching(true)
-          setMeasureToolArmed(false)
+          disarmMeasure()
         } else if (dimensionToolStretching) {
           setDimensionToolStretching(false)
         } else if (dimensionToolVisible) {

--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -292,6 +292,15 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
         </ToolbarButton>
 
         <ToolbarButton
+          style={{}}
+          onClick={() => {
+            window.dispatchEvent(new Event("arm-dimension-tool"))
+          }}
+        >
+          <div>📏</div>
+        </ToolbarButton>
+
+        <ToolbarButton
           onClick={() => {
             setViewMenuOpen(!isViewMenuOpen)
           }}

--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -113,6 +113,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
   const [isViewMenuOpen, setViewMenuOpen] = useState(false)
   const [isLayerMenuOpen, setLayerMenuOpen] = useState(false)
   const [isErrorsOpen, setErrorsOpen] = useState(false)
+  const [measureToolArmed, setMeasureToolArmed] = useState(false)
   const [selectedLayer, selectLayer] = useGlobalStore(
     (s) => [s.selected_layer, s.selectLayer] as const,
   )
@@ -140,6 +141,17 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     (s) => s.setIsShowingAutorouting,
   )
   const setIsShowingDrcErrors = useGlobalStore((s) => s.setIsShowingDrcErrors)
+
+  useEffect(() => {
+    const arm = () => setMeasureToolArmed(true)
+    const disarm = () => setMeasureToolArmed(false)
+    window.addEventListener("arm-dimension-tool", arm)
+    window.addEventListener("disarm-dimension-tool", disarm)
+    return () => {
+      window.removeEventListener("arm-dimension-tool", arm)
+      window.removeEventListener("disarm-dimension-tool", disarm)
+    }
+  }, [])
 
   useHotKey("1", () => selectLayer("top"))
   useHotKey("2", () => selectLayer("bottom"))
@@ -292,8 +304,9 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
         </ToolbarButton>
 
         <ToolbarButton
-          style={{}}
+          style={measureToolArmed ? { backgroundColor: "#444" } : {}}
           onClick={() => {
+            setMeasureToolArmed(true)
             window.dispatchEvent(new Event("arm-dimension-tool"))
           }}
         >


### PR DESCRIPTION


https://github.com/user-attachments/assets/237835cf-a2e2-4a6c-8774-024d7dfe92e4



## Summary
- add toolbar button to toggle measure mode by dispatching `arm-dimension-tool` event
- allow dimension overlay to start measuring from first click rather than on activation

## Testing
- `bun test`
- `bun run format`


------
https://chatgpt.com/codex/tasks/task_b_686d7498541c832e915c0f6344ee7e43