### PR TITLE
patch(global-store): set default pcb groups visibility to true

### DIFF
--- a/src/global-store.ts
+++ b/src/global-store.ts
@@ -61,7 +61,7 @@ export const createStore = (initialState: Partial<StateProps> = {}) =>
         is_showing_rats_nest: false,
         is_showing_autorouting: true,
         is_showing_drc_errors: true,
-        is_showing_pcb_groups: false,
+        is_showing_pcb_groups: true,
         ...initialState,
 
         selectLayer: (layer) => set({ selected_layer: layer }),


### PR DESCRIPTION
The default visibility of PCB groups was incorrectly set to false, which could cause confusion for users expecting to see grouped PCB elements by default. This change aligns with common user expectations and typical workflow requirements.

<img width="486" height="60" alt="image" src="https://github.com/user-attachments/assets/84a1f013-218b-45ae-8187-8135a081f6ec" />
