### PR TITLE
feat: add manual board editing (resize & move) with snap + min size Body

### DIFF
--- a/src/PCBViewer.tsx
+++ b/src/PCBViewer.tsx
@@ -1,51 +1,56 @@
-import { applyEditEvents } from "@tscircuit/core"
-import { findBoundsAndCenter } from "@tscircuit/soup-util"
-import type { AnyCircuitElement, SourceTrace } from "circuit-json"
-import { ContextProviders } from "./components/ContextProviders"
-import type { StateProps } from "./global-store"
-import type { GraphicsObject } from "graphics-debug"
-import { ToastContainer } from "lib/toast"
-import { useEffect, useMemo, useRef, useState } from "react"
-import { useMeasure } from "react-use"
-import { compose, scale, translate } from "transformation-matrix"
-import useMouseMatrixTransform from "use-mouse-matrix-transform"
-import { CanvasElementsRenderer } from "./components/CanvasElementsRenderer"
-import type { ManualEditEvent } from "@tscircuit/props"
-import { zIndexMap } from "lib/util/z-index-map"
-import { calculateCircuitJsonKey } from "lib/calculate-circuit-json-key"
+import { applyEditEvents } from "@tscircuit/core";
+import { findBoundsAndCenter } from "@tscircuit/soup-util";
+import type { AnyCircuitElement, SourceTrace } from "circuit-json";
+import { ContextProviders } from "./components/ContextProviders";
+import type { StateProps } from "./global-store";
+import type { GraphicsObject } from "graphics-debug";
+import { ToastContainer } from "lib/toast";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useMeasure } from "react-use";
+import { compose, scale, translate, applyToPoint } from "transformation-matrix";
+import useMouseMatrixTransform from "use-mouse-matrix-transform";
+import { CanvasElementsRenderer } from "./components/CanvasElementsRenderer";
+import type { ManualEditEvent } from "@tscircuit/props";
+import { zIndexMap } from "lib/util/z-index-map";
+import { calculateCircuitJsonKey } from "lib/calculate-circuit-json-key";
+import { EditBoardOverlay } from "./components/EditBoardOverlay";
 
-const defaultTransform = compose(translate(400, 300), scale(40, -40))
+const defaultTransform = compose(translate(400, 300), scale(40, -40));
 
 type Props = {
-  circuitJson?: AnyCircuitElement[]
-  height?: number
-  allowEditing?: boolean
-  editEvents?: ManualEditEvent[]
-  initialState?: Partial<StateProps>
-  onEditEventsChanged?: (editEvents: ManualEditEvent[]) => void
-  focusOnHover?: boolean
-  clickToInteractEnabled?: boolean
-  debugGraphics?: GraphicsObject | null
-  disablePcbGroups?: boolean
-}
+  circuitJson?: AnyCircuitElement[];
+  height?: number;
+  allowEditing?: boolean;
+  boardSnapMm?: number;
+  editEvents?: ManualEditEvent[];
+  initialState?: Partial<StateProps>;
+  onEditEventsChanged?: (editEvents: ManualEditEvent[]) => void;
+  focusOnHover?: boolean;
+  clickToInteractEnabled?: boolean;
+  debugGraphics?: GraphicsObject | null;
+  disablePcbGroups?: boolean;
+  boardMinSizeMn?: number;
+};
 
 export const PCBViewer = ({
   circuitJson,
   debugGraphics,
   height = 600,
   initialState,
+  boardSnapMm = 1,
   allowEditing = true,
   editEvents: editEventsProp,
   onEditEventsChanged,
   focusOnHover = false,
   clickToInteractEnabled = false,
   disablePcbGroups = false,
+  boardMinSizeMn = 5
 }: Props) => {
   const [isInteractionEnabled, setIsInteractionEnabled] = useState(
-    !clickToInteractEnabled,
-  )
-  const [ref, refDimensions] = useMeasure()
-  const [transform, setTransformInternal] = useState(defaultTransform)
+    !clickToInteractEnabled
+  );
+  const [ref, refDimensions] = useMeasure();
+  const [transform, setTransformInternal] = useState(defaultTransform);
   const {
     ref: transformRef,
     setTransform,
@@ -54,92 +59,210 @@ export const PCBViewer = ({
     transform,
     onSetTransform: setTransformInternal,
     enabled: isInteractionEnabled,
-  })
+  });
 
-  let [editEvents, setEditEvents] = useState<ManualEditEvent[]>([])
-  editEvents = editEventsProp ?? editEvents
+  let [editEvents, setEditEvents] = useState<ManualEditEvent[]>([]);
+  editEvents = editEventsProp ?? editEvents;
 
-  const initialRenderCompleted = useRef(false)
-  const touchStartRef = useRef<{ x: number; y: number } | null>(null)
+  const initialRenderCompleted = useRef(false);
+  const touchStartRef = useRef<{ x: number; y: number } | null>(null);
   const circuitJsonKey = useMemo(
     () => calculateCircuitJsonKey(circuitJson),
-    [circuitJson],
-  )
+    [circuitJson]
+  );
 
+  // ---- Undo stack for ESC-after-release
+  const undoRef = useRef<
+    {
+      size?: { width: number; height: number };
+      offset: { x: number; y: number };
+    }[]
+  >([]);
+
+  // ---- Base elements (pcb_ + source_) BEFORE viewer-local board edits
+  const pcbElmsPreEdit = useMemo(() => {
+    return (
+      circuitJson?.filter(
+        (e: any) => e.type.startsWith("pcb_") || e.type.startsWith("source_")
+      ) ?? []
+    );
+  }, [circuitJsonKey]);
+
+  const elementsCoreApplied = useMemo(() => {
+    return applyEditEvents({
+      circuitJson: pcbElmsPreEdit as any,
+      editEvents,
+    });
+  }, [pcbElmsPreEdit, editEvents]);
+
+  // ---- Extract viewer-local board edits from editEvents
+  const boardEdits = useMemo(() => {
+    let size: { width: number; height: number } | undefined;
+    let offset = { x: 0, y: 0 };
+
+    for (const e of editEvents as any[]) {
+      if (e?.type === "board_size_edit" && typeof e.width === "number") {
+        size = { width: e.width, height: e.height };
+      } else if (e?.type === "board_offset_edit" && e.offset) {
+        offset.x += e.offset.x || 0;
+        offset.y += e.offset.y || 0;
+      }
+    }
+    return { size, offset };
+  }, [editEvents]);
+
+  // ---- Apply size override to board element (viewer-local)
+  const elementsFinal = useMemo(() => {
+    if (!boardEdits.size) return elementsCoreApplied as AnyCircuitElement[];
+    const { width, height } = boardEdits.size;
+    return (elementsCoreApplied as AnyCircuitElement[]).map((el: any) =>
+      el?.type === "pcb_board" ? { ...el, width, height } : el
+    );
+  }, [elementsCoreApplied, boardEdits.size]);
+
+  // ---- Apply offset as an extra world-translation in the view transform
+  const effectiveTransform = useMemo(() => {
+    const off = boardEdits.offset;
+    if (!off || (off.x === 0 && off.y === 0)) return transform;
+    // screen = transform * translate(offset) * world
+    return compose(transform, translate(off.x, off.y));
+  }, [transform, boardEdits.offset.x, boardEdits.offset.y]);
+
+  // ---- Compute a screen-space board rect for the overlay (after our edits)
+  const boardRect = useMemo(() => {
+    const pcbBoardEls = (elementsFinal as any[]).filter(
+      (e) => e.type === "pcb_board"
+    );
+    if (pcbBoardEls.length === 0) return undefined;
+
+    const { center, width, height } = findBoundsAndCenter(pcbBoardEls as any);
+    const topLeftWorld = { x: center.x - width / 2, y: center.y - height / 2 };
+    const bottomRightWorld = {
+      x: center.x + width / 2,
+      y: center.y + height / 2,
+    };
+
+    const tl = applyToPoint(effectiveTransform, topLeftWorld);
+    const br = applyToPoint(effectiveTransform, bottomRightWorld);
+
+    const left = Math.min(tl.x, br.x);
+    const top = Math.min(tl.y, br.y);
+    const w = Math.abs(br.x - tl.x);
+    const h = Math.abs(br.y - tl.y);
+
+    return { x: left, y: top, width: w, height: h };
+  }, [elementsFinal, effectiveTransform]);
+
+  // ---- Fit view helper (uses post-edit elements)
   const resetTransform = () => {
     const elmBounds =
-      refDimensions?.width > 0 ? refDimensions : { width: 500, height: 500 }
-    const { center, width, height } = elements.some((e) =>
-      e.type.startsWith("pcb_"),
+      refDimensions?.width > 0 ? refDimensions : { width: 500, height: 500 };
+    const { center, width, height } = elementsFinal.some((e) =>
+      e.type.startsWith("pcb_")
     )
       ? findBoundsAndCenter(
-          elements.filter((e) => e.type.startsWith("pcb_")) as any,
+          elementsFinal.filter((e) => e.type.startsWith("pcb_")) as any
         )
-      : { center: { x: 0, y: 0 }, width: 0.001, height: 0.001 }
+      : { center: { x: 0, y: 0 }, width: 0.001, height: 0.001 };
     const scaleFactor =
       Math.min(
         (elmBounds.width ?? 0) / width,
         (elmBounds.height ?? 0) / height,
-        100,
-      ) * 0.75
+        100
+      ) * 0.75;
 
     const targetTransform = compose(
       translate((elmBounds.width ?? 0) / 2, (elmBounds.height ?? 0) / 2),
       scale(scaleFactor, -scaleFactor, 0, 0),
-      translate(-center.x, -center.y),
-    )
+      translate(-center.x, -center.y)
+    );
 
-    setTransform(targetTransform)
-    return
-  }
+    setTransform(targetTransform);
+  };
 
+  // ---- initial fit
   useEffect(() => {
-    if (!refDimensions?.width) return
-    if (!circuitJson) return
-    if (circuitJson.length === 0) return
+    if (!refDimensions?.width) return;
+    if (!circuitJson) return;
+    if (circuitJson.length === 0) return;
 
     if (!initialRenderCompleted.current) {
-      resetTransform()
-      initialRenderCompleted.current = true
+      resetTransform();
+      initialRenderCompleted.current = true;
     }
-  }, [circuitJson, refDimensions])
+  }, [circuitJson, refDimensions, elementsFinal]);
 
-  const pcbElmsPreEdit = useMemo(() => {
-    return (
-      circuitJson?.filter(
-        (e: any) => e.type.startsWith("pcb_") || e.type.startsWith("source_"),
-      ) ?? []
-    )
-  }, [circuitJsonKey])
+  // ---- ESC-to-undo (post-release)
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const isEsc =
+        e.key === "Escape" || e.code === "Escape" || (e as any).keyCode === 27;
+      if (!isEsc) return;
+      if (undoRef.current.length === 0) return;
 
-  const elements = useMemo(() => {
-    return applyEditEvents({
-      circuitJson: pcbElmsPreEdit as any,
-      editEvents,
-    })
-  }, [pcbElmsPreEdit, editEvents])
+      e.preventDefault();
+      e.stopPropagation();
+
+      const prev = undoRef.current.pop()!;
+      const base = (editEvents as any[]).filter(
+        (ev) => ev.type !== "board_size_edit" && ev.type !== "board_offset_edit"
+      );
+
+      const additions: any[] = [];
+      if (prev.offset && (prev.offset.x !== 0 || prev.offset.y !== 0)) {
+        additions.push({
+          type: "board_offset_edit",
+          edit_event_id: `board-offset-undo`,
+          offset: { x: prev.offset.x, y: prev.offset.y },
+        });
+      }
+      if (prev.size) {
+        additions.push({
+          type: "board_size_edit",
+          edit_event_id: `board-size-undo`,
+          width: prev.size.width,
+          height: prev.size.height,
+        });
+      }
+
+      const newEvents = [...base, ...additions] as unknown as ManualEditEvent[];
+      setEditEvents(newEvents);
+      onEditEventsChanged?.(newEvents);
+      console.log("[EditBoard] undo -> restored:", additions);
+    };
+
+    window.addEventListener("keydown", onKey, true);
+    document.addEventListener("keydown", onKey, true);
+    return () => {
+      window.removeEventListener("keydown", onKey, true);
+      document.removeEventListener("keydown", onKey, true);
+    };
+  }, [editEvents, onEditEventsChanged]);
 
   const onCreateEditEvent = (event: ManualEditEvent) => {
-    setEditEvents([...editEvents, event])
-    onEditEventsChanged?.([...editEvents, event])
-  }
+    setEditEvents([...editEvents, event]);
+    onEditEventsChanged?.([...editEvents, event]);
+  };
   const onModifyEditEvent = (modifiedEvent: Partial<ManualEditEvent>) => {
     const newEditEvents: ManualEditEvent[] = editEvents.map((e) =>
       e.edit_event_id === modifiedEvent.edit_event_id
         ? ({ ...e, ...modifiedEvent } as ManualEditEvent)
-        : e,
-    )
-    setEditEvents(newEditEvents)
-    onEditEventsChanged?.(newEditEvents)
-  }
+        : e
+    );
+    setEditEvents(newEditEvents);
+    onEditEventsChanged?.(newEditEvents);
+  };
 
   const mergedInitialState = useMemo(
     () => ({
       ...initialState,
       ...(disablePcbGroups && { is_showing_pcb_groups: false }),
     }),
-    [initialState, disablePcbGroups],
-  )
+    [initialState, disablePcbGroups]
+  );
+
+  // helper to generate ids for our local board events
+  const _mkId = () => Math.random().toString(36).slice(2, 10);
 
   return (
     <div ref={transformRef as any} style={{ position: "relative" }}>
@@ -150,7 +273,7 @@ export const PCBViewer = ({
         >
           <CanvasElementsRenderer
             key={refDimensions.width}
-            transform={transform}
+            transform={effectiveTransform}
             height={height}
             width={refDimensions.width}
             allowEditing={allowEditing}
@@ -167,40 +290,134 @@ export const PCBViewer = ({
                 bottom: 0,
               },
             }}
-            elements={elements as SourceTrace[]}
+            elements={elementsFinal as SourceTrace[]}
             debugGraphics={debugGraphics}
           />
+
+          {/* Edit Board overlay */}
+          <EditBoardOverlay
+            boardRect={boardRect}
+            transform={effectiveTransform}
+            onProposeEdit={(proposal) => {
+              // ---- snapshot current applied edits for undo
+              undoRef.current.push({
+                size: boardEdits.size ? { ...boardEdits.size } : undefined,
+                offset: { ...boardEdits.offset },
+              });
+              if (undoRef.current.length > 50) undoRef.current.shift();
+
+              // snap helper (1 mm grid)
+              const spacing = boardSnapMm;    
+              const snap = (v: number) => Math.round(v / spacing) * spacing;
+
+              // snapped + clamped copy
+              const prop = { ...proposal };
+              if (prop.offset) {
+                prop.offset = {
+                  x: snap(prop.offset.x),
+                  y: snap(prop.offset.y),
+                };
+              }
+              if (prop.size) {
+                prop.size = {
+                  width: Math.max(boardMinSizeMn, prop.size.width),
+                  height: Math.max(boardMinSizeMn, prop.size.height),
+                };
+              }
+
+              // remove prior board_* edits; coalesce to one of each
+              const base = (editEvents as any[]).filter(
+                (e) =>
+                  e.type !== "board_size_edit" && e.type !== "board_offset_edit"
+              );
+
+              const additions: any[] = [];
+
+              // current applied values
+              const curOffset = boardEdits.offset;
+              const curSize = boardEdits.size;
+
+              // OFFSET: cumulative total (only if changed)
+              if (prop.offset) {
+                const combined = {
+                  x: snap(curOffset.x + prop.offset.x),
+                  y: snap(curOffset.y + prop.offset.y),
+                };
+                const offsetChanged =
+                  combined.x !== curOffset.x || combined.y !== curOffset.y;
+                if (offsetChanged) {
+                  additions.push({
+                    type: "board_offset_edit",
+                    edit_event_id: `board-offset-${_mkId()}`,
+                    offset: combined,
+                  });
+                }
+              }
+
+              // SIZE: latest absolute size (only if changed)
+              if (prop.size) {
+                const sizeChanged =
+                  !curSize ||
+                  curSize.width !== prop.size.width ||
+                  curSize.height !== prop.size.height;
+
+                if (sizeChanged) {
+                  additions.push({
+                    type: "board_size_edit",
+                    edit_event_id: `board-size-${_mkId()}`,
+                    width: prop.size.width,
+                    height: prop.size.height,
+                  });
+                }
+              }
+
+              if (additions.length === 0) return;
+
+              const newEvents = [
+                ...base,
+                ...additions,
+              ] as unknown as ManualEditEvent[];
+              setEditEvents(newEvents);
+              onEditEventsChanged?.(newEvents);
+
+              console.log(
+                "[EditBoard] emitted (snapped, min-clamped, coalesced):",
+                additions
+              );
+            }}
+          />
+
           <ToastContainer />
         </ContextProviders>
       </div>
       {clickToInteractEnabled && !isInteractionEnabled && (
         <div
           onClick={() => {
-            setIsInteractionEnabled(true)
-            resetTransform()
+            setIsInteractionEnabled(true);
+            resetTransform();
           }}
           onTouchStart={(e) => {
-            const touch = e.touches[0]
+            const touch = e.touches[0];
             touchStartRef.current = {
               x: touch.clientX,
               y: touch.clientY,
-            }
+            };
           }}
           onTouchEnd={(e) => {
-            const touch = e.changedTouches[0]
-            const start = touchStartRef.current
-            if (!start) return
+            const touch = e.changedTouches[0];
+            const start = touchStartRef.current;
+            if (!start) return;
 
-            const deltaX = Math.abs(touch.clientX - start.x)
-            const deltaY = Math.abs(touch.clientY - start.y)
+            const deltaX = Math.abs(touch.clientX - start.x);
+            const deltaY = Math.abs(touch.clientY - start.y);
 
             if (deltaX < 10 && deltaY < 10) {
-              e.preventDefault()
-              setIsInteractionEnabled(true)
-              resetTransform()
+              e.preventDefault();
+              setIsInteractionEnabled(true);
+              resetTransform();
             }
 
-            touchStartRef.current = null
+            touchStartRef.current = null;
           }}
           style={{
             position: "absolute",
@@ -231,5 +448,5 @@ export const PCBViewer = ({
         </div>
       )}
     </div>
-  )
-}
+  );
+};

--- a/src/components/EditBoardOverlay.tsx
+++ b/src/components/EditBoardOverlay.tsx
@@ -1,0 +1,348 @@
+import React, { useEffect, useRef, useState } from "react"
+import { useGlobalStore } from "../global-store"
+import { inverse, applyToPoint, type Matrix } from "transformation-matrix"
+
+type Rect = { x: number; y: number; width: number; height: number }
+
+type Props = {
+  /** Screen-space rect (pixels) from PCBViewer */
+  boardRect?: Rect
+  /** Canvas transform matrix from PCBViewer (world->screen) */
+  transform: Matrix
+  /** Report proposed edit in WORLD units (mm) on end of drag */
+  onProposeEdit?: (args: {
+    size?: { width: number; height: number }
+    offset?: { x: number; y: number }
+  }) => void
+}
+
+const overlayStyle: React.CSSProperties = {
+  position: "absolute",
+  inset: 0,
+  pointerEvents: "none",
+}
+
+const handleSize = 10 // px
+const minSize = 8 // px (screen)
+
+function clampSize(v: number) {
+  return Math.max(minSize, v)
+}
+
+function handlesFor(r: Rect) {
+  const cx = r.x + r.width / 2
+  const cy = r.y + r.height / 2
+  return [
+    { id: "nw" as const, x: r.x - handleSize / 2, y: r.y - handleSize / 2, cursor: "nwse-resize" },
+    { id: "n"  as const, x: cx - handleSize / 2, y: r.y - handleSize / 2, cursor: "ns-resize" },
+    { id: "ne" as const, x: r.x + r.width - handleSize / 2, y: r.y - handleSize / 2, cursor: "nesw-resize" },
+    { id: "e"  as const, x: r.x + r.width - handleSize / 2, y: cy - handleSize / 2, cursor: "ew-resize" },
+    { id: "se" as const, x: r.x + r.width - handleSize / 2, y: r.y + r.height - handleSize / 2, cursor: "nwse-resize" },
+    { id: "s"  as const, x: cx - handleSize / 2, y: r.y + r.height - handleSize / 2, cursor: "ns-resize" },
+    { id: "sw" as const, x: r.x - handleSize / 2, y: r.y + r.height - handleSize / 2, cursor: "nesw-resize" },
+    { id: "w"  as const, x: r.x - handleSize / 2, y: cy - handleSize / 2, cursor: "ew-resize" },
+  ]
+}
+
+type DragKind =
+  | { type: "none" }
+  | { type: "move"; startX: number; startY: number; startRect: Rect }
+  | {
+      type: "resize"
+      handle: ReturnType<typeof handlesFor>[number]["id"]
+      startX: number
+      startY: number
+      startRect: Rect
+    }
+
+export const EditBoardOverlay: React.FC<Props> = ({
+  boardRect,
+  transform,
+  onProposeEdit,
+}) => {
+  const in_edit_board_mode = useGlobalStore((s) => s.in_edit_board_mode)
+  const [draft, setDraft] = useState<Rect | undefined>(boardRect)
+  const dragRef = useRef<DragKind>({ type: "none" })
+  const activePointerId = useRef<number | null>(null)
+
+  // Keep draft synced when not dragging
+  useEffect(() => {
+    if (dragRef.current.type === "none") setDraft(boardRect)
+  }, [boardRect])
+
+  // Ensure ESC works by forcing focus to the canvas/iframe on drag start
+  const ensureWindowFocus = () => {
+    try {
+      window.focus()
+      const active = document.activeElement as HTMLElement | null
+      if (active && typeof active.blur === "function") active.blur()
+      ;(document.body as any)?.focus?.()
+    } catch {}
+  }
+
+  // Pointer-based drag lifecycle (mouse/touch/pen)
+  useEffect(() => {
+    function onMove(e: PointerEvent) {
+      if (activePointerId.current !== null && e.pointerId !== activePointerId.current) return
+      if (!draft) return
+      const d = dragRef.current
+      if (d.type === "move") {
+        const dx = e.clientX - d.startX
+        const dy = e.clientY - d.startY
+        setDraft({ ...d.startRect, x: d.startRect.x + dx, y: d.startRect.y + dy })
+      } else if (d.type === "resize") {
+        const dx = e.clientX - d.startX
+        const dy = e.clientY - d.startY
+        let { x, y, width, height } = d.startRect
+
+        switch (d.handle) {
+          case "nw":
+            x = d.startRect.x + dx
+            y = d.startRect.y + dy
+            width = clampSize(d.startRect.width - dx)
+            height = clampSize(d.startRect.height - dy)
+            break
+          case "n":
+            y = d.startRect.y + dy
+            height = clampSize(d.startRect.height - dy)
+            break
+          case "ne":
+            y = d.startRect.y + dy
+            width = clampSize(d.startRect.width + dx)
+            height = clampSize(d.startRect.height - dy)
+            break
+          case "e":
+            width = clampSize(d.startRect.width + dx)
+            break
+          case "se":
+            width = clampSize(d.startRect.width + dx)
+            height = clampSize(d.startRect.height + dy)
+            break
+          case "s":
+            height = clampSize(d.startRect.height + dy)
+            break
+          case "sw":
+            x = d.startRect.x + dx
+            width = clampSize(d.startRect.width - dx)
+            height = clampSize(d.startRect.height + dy)
+            break
+          case "w":
+            x = d.startRect.x + dx
+            width = clampSize(d.startRect.width - dx)
+            break
+        }
+
+        // Prevent inverted rects if we hit min size
+        if (width <= minSize) {
+          x =
+            d.startRect.x +
+            (d.handle === "nw" || d.handle === "w" || d.handle === "sw"
+              ? d.startRect.width - minSize
+              : 0)
+        }
+        if (height <= minSize) {
+          y =
+            d.startRect.y +
+            (d.handle === "nw" || d.handle === "n" || d.handle === "ne"
+              ? d.startRect.height - minSize
+              : 0)
+        }
+
+        setDraft({ x, y, width, height })
+      }
+    }
+
+    function commitAndClear() {
+      if (dragRef.current.type === "none" || !draft || !boardRect) {
+        activePointerId.current = null
+        dragRef.current = { type: "none" }
+        return
+      }
+      const d = dragRef.current
+      activePointerId.current = null
+      dragRef.current = { type: "none" }
+
+      if (!onProposeEdit) return
+
+      // Convert screen→world using inverse(transform)
+      const inv = inverse(transform)
+      const rectToWorld = (r: Rect) => {
+        const tl = applyToPoint(inv, { x: r.x, y: r.y })
+        const br = applyToPoint(inv, { x: r.x + r.width, y: r.y + r.height })
+        const left = Math.min(tl.x, br.x)
+        const top = Math.min(tl.y, br.y)
+        const w = Math.abs(br.x - tl.x)
+        const h = Math.abs(br.y - tl.y)
+        return { x: left, y: top, width: w, height: h }
+      }
+
+      const startWorld = rectToWorld(boardRect)
+      const endWorld = rectToWorld(draft)
+
+      const payload: {
+        size?: { width: number; height: number }
+        offset?: { x: number; y: number }
+      } = {}
+
+      if (d.type === "move") {
+        payload.offset = {
+          x: endWorld.x - startWorld.x,
+          y: endWorld.y - startWorld.y,
+        }
+      } else if (d.type === "resize") {
+        payload.size = {
+          width: endWorld.width,
+          height: endWorld.height,
+        }
+      }
+
+      onProposeEdit(payload)
+    }
+
+    const onUp = (e: PointerEvent) => {
+      if (activePointerId.current !== null && e.pointerId !== activePointerId.current) return
+      try { (e.target as Element)?.releasePointerCapture?.(e.pointerId) } catch {}
+      commitAndClear()
+    }
+
+    const onCancel = (e: PointerEvent) => {
+      if (activePointerId.current !== null && e.pointerId !== activePointerId.current) return
+      try { (e.target as Element)?.releasePointerCapture?.(e.pointerId) } catch {}
+      // cancel drag (don’t emit)
+      dragRef.current = { type: "none" }
+      activePointerId.current = null
+      setDraft(boardRect)
+    }
+
+    window.addEventListener("pointermove", onMove, { passive: true })
+    window.addEventListener("pointerup", onUp, { passive: true })
+    window.addEventListener("pointercancel", onCancel, { passive: true })
+    return () => {
+      window.removeEventListener("pointermove", onMove)
+      window.removeEventListener("pointerup", onUp)
+      window.removeEventListener("pointercancel", onCancel)
+    }
+  }, [draft, transform, onProposeEdit, boardRect])
+
+  // ESC-to-cancel while dragging (no emit)
+  useEffect(() => {
+    const cancel = () => {
+      if (dragRef.current.type !== "none") {
+        dragRef.current = { type: "none" }
+        activePointerId.current = null
+        setDraft(boardRect)
+      }
+    }
+
+    const onKey = (e: KeyboardEvent) => {
+      const isEsc = e.key === "Escape" || e.code === "Escape" || (e as any).keyCode === 27
+      if (!isEsc) return
+      e.preventDefault()
+      e.stopPropagation()
+      cancel()
+    }
+
+    // capture phase so we win over other handlers / iframes
+    window.addEventListener("keydown", onKey, true)
+    document.addEventListener("keydown", onKey, true)
+
+    // if focus is lost mid-drag, cancel
+    const onBlur = () => cancel()
+    window.addEventListener("blur", onBlur)
+
+    return () => {
+      window.removeEventListener("keydown", onKey, true)
+      document.removeEventListener("keydown", onKey, true)
+      window.removeEventListener("blur", onBlur)
+    }
+  }, [boardRect])
+
+  if (!in_edit_board_mode || !draft) return null
+
+  const handles = handlesFor(draft)
+
+  return (
+    <div style={overlayStyle}>
+      {/* Highlight */}
+      <div
+        style={{
+          position: "absolute",
+          left: draft.x,
+          top: draft.y,
+          width: draft.width,
+          height: draft.height,
+          border: "2px dashed #8bd3ff",
+          background: "rgba(139, 211, 255, 0.06)",
+          borderRadius: 2,
+          pointerEvents: "none",
+        }}
+      />
+
+      {/* Handles (pointer-enabled) */}
+      {handles.map((h) => (
+        <div
+          key={h.id}
+          onPointerDown={(e) => {
+            e.preventDefault()
+            e.stopPropagation()
+            ensureWindowFocus()
+            activePointerId.current = e.pointerId
+            try { (e.currentTarget as Element).setPointerCapture(e.pointerId) } catch {}
+            dragRef.current = {
+              type: "resize",
+              handle: h.id,
+              startX: e.clientX,
+              startY: e.clientY,
+              startRect: draft,
+            }
+          }}
+          style={{
+            position: "absolute",
+            left: h.x,
+            top: h.y,
+            width: handleSize,
+            height: handleSize,
+            borderRadius: 2,
+            border: "1px solid #8bd3ff",
+            background: "rgba(139, 211, 255, 0.9)",
+            boxShadow: "0 0 0 1px rgba(0,0,0,0.35) inset",
+            pointerEvents: "auto",
+            cursor: h.cursor as any,
+            touchAction: "none",
+          }}
+          title={`Resize: ${h.id.toUpperCase()}`}
+        />
+      ))}
+
+      {/* Drag surface (offset) */}
+      <div
+        onPointerDown={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          ensureWindowFocus()
+          activePointerId.current = e.pointerId
+          try { (e.currentTarget as Element).setPointerCapture(e.pointerId) } catch {}
+          dragRef.current = {
+            type: "move",
+            startX: e.clientX,
+            startY: e.clientY,
+            startRect: draft,
+          }
+        }}
+        style={{
+          position: "absolute",
+          left: draft.x + 6,
+          top: draft.y + 6,
+          width: Math.max(0, draft.width - 12),
+          height: Math.max(0, draft.height - 12),
+          pointerEvents: "auto",
+          cursor: "move",
+          touchAction: "none",
+        }}
+        title="Drag to offset"
+      />
+    </div>
+  )
+}
+
+export default EditBoardOverlay

--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -150,6 +150,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     is_showing_autorouting,
     is_showing_drc_errors,
     is_showing_pcb_groups,
+    in_edit_board_mode,
   ] = useGlobalStore((s) => [
     s.in_move_footprint_mode,
     s.in_draw_trace_mode,
@@ -158,6 +159,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     s.is_showing_autorouting,
     s.is_showing_drc_errors,
     s.is_showing_pcb_groups,
+    s.in_edit_board_mode,
   ])
   const setEditMode = useGlobalStore((s) => s.setEditMode)
   const setIsShowingRatsNest = useGlobalStore((s) => s.setIsShowingRatsNest)
@@ -476,6 +478,21 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
             Move Components
           </div>
         </ToolbarButton>
+
+        {/* NEW: Edit Board toggle */}
+        <ToolbarButton
+          isSmallScreen={isSmallScreen}
+          style={{}}
+          onClick={() => {
+            setEditMode(in_edit_board_mode ? "off" : "edit_board")
+          }}
+        >
+          <div>
+            {in_edit_board_mode ? "✖ " : ""}
+            Edit Board
+          </div>
+        </ToolbarButton>
+
         <ToolbarButton
           isSmallScreen={isSmallScreen}
           style={{}}

--- a/src/examples/manual-edit-board.fixture.tsx
+++ b/src/examples/manual-edit-board.fixture.tsx
@@ -1,0 +1,29 @@
+import React from "react"
+import { PCBViewer } from "../PCBViewer"                 // ✅ correct path
+import type { AnyCircuitElement } from "circuit-json"
+import type { ManualEditEvent } from "@tscircuit/props"
+
+const circuit: AnyCircuitElement[] = [
+  {
+    type: "pcb_board",
+    width: 20,
+    height: 12,
+    center: { x: 0, y: 0 },                              // keep if allowed
+  } as AnyCircuitElement,                                 // cast to relax literal checks
+]
+
+export default function ManualEditBoardFixture() {
+  return (
+    <div style={{ width: 900, height: 600 }}>
+      <PCBViewer
+        circuitJson={circuit}
+        height={600}
+        allowEditing
+        initialState={{ in_edit_board_mode: true }}
+        onEditEventsChanged={(evts: ManualEditEvent[]) => {
+          console.log("[fixture] editEvents:", evts)
+        }}
+      />
+    </div>
+  )
+}

--- a/src/global-store.ts
+++ b/src/global-store.ts
@@ -20,6 +20,8 @@ export interface State {
   in_edit_mode: boolean
   in_move_footprint_mode: boolean
   in_draw_trace_mode: boolean
+  in_edit_board_mode: boolean
+
   is_mouse_over_container: boolean
   is_moving_component: boolean
   is_drawing_trace: boolean
@@ -31,7 +33,9 @@ export interface State {
   is_showing_pcb_groups: boolean
 
   selectLayer: (layer: LayerRef) => void
-  setEditMode: (mode: "off" | "move_footprint" | "draw_trace") => void
+  setEditMode: (
+    mode: "off" | "move_footprint" | "draw_trace" | "edit_board",
+  ) => void
   setIsMovingComponent: (is_moving: boolean) => void
   setIsDrawingTrace: (is_drawing: boolean) => void
   setIsShowingRatsNest: (is_showing: boolean) => void
@@ -60,6 +64,7 @@ export const createStore = (
         in_edit_mode: false,
         in_move_footprint_mode: false,
         in_draw_trace_mode: false,
+        in_edit_board_mode: false,
 
         is_moving_component: false,
         is_drawing_trace: false,
@@ -80,6 +85,7 @@ export const createStore = (
             in_edit_mode: mode !== "off",
             in_move_footprint_mode: mode === "move_footprint",
             in_draw_trace_mode: mode === "draw_trace",
+            in_edit_board_mode: mode === "edit_board",
             is_moving_component: false,
             is_drawing_trace: false,
           }),


### PR DESCRIPTION
This PR introduces a new `EditBoardOverlay` component and integrates it into `PCBViewer` to allow manual editing of board size and position.

### Features
- New "Edit Board" mode toggle in toolbar.
- Drag handles to resize board; drag inside to move board.
- ESC cancels current drag, or undoes last committed change.
- Snap-to-grid support (`boardSnapMm`, default 1 mm).
- Minimum board size clamp (`boardMinSizeMm`, default 5 mm).
- New fixture: `manual-edit-board.fixture.tsx` for quick testing.

### Demo
- Run `bun dev` and open the new fixture (`manual-edit-board`).
- Try resizing/moving; press ESC during drag (cancel) or after release (undo).
- Adjust snap/min size via props to verify.

This lays the groundwork for richer manual edit interactions in `pcb-viewer`.

https://github.com/user-attachments/assets/eec536c1-3f7c-4d0d-a808-bf5ba8be925d

/attempt #106 
