### PR TITLE
feat: add polygon shape support for pcb_smtpad

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,7 +6,7 @@
       "dependencies": {
         "@emotion/css": "^11.11.2",
         "@vitejs/plugin-react": "^5.0.2",
-        "circuit-to-svg": "^0.0.166",
+        "circuit-to-svg": "^0.0.191",
         "color": "^4.2.3",
         "react-supergrid": "^1.0.10",
         "react-toastify": "^10.0.5",
@@ -573,7 +573,7 @@
 
     "circuit-json-to-simple-3d": ["circuit-json-to-simple-3d@0.0.8", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-ZQJB625ntNUS0hC3dFZtyFS+t2oL4PVysHlNQdGqpJFefwRXLCOjiXj0qS4ihE1SSl8indv+FCoCzJS/Kp6JHw=="],
 
-    "circuit-to-svg": ["circuit-to-svg@0.0.166", "", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" }, "peerDependencies": { "@tscircuit/circuit-json-util": "*", "@tscircuit/footprinter": "*", "circuit-json": "*", "schematic-symbols": "*" } }, "sha512-yyNbFq18y8ZMP2fYNtA3HmARYWRt38S+ThZu1LuNaSlnHl4g9iYwH5unNoXD9a23cgBDiOtytescdP7fSm6TFg=="],
+    "circuit-to-svg": ["circuit-to-svg@0.0.191", "https://registry.npmmirror.com/circuit-to-svg/-/circuit-to-svg-0.0.191.tgz", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" }, "peerDependencies": { "tscircuit": "*" } }, "sha512-F9W+eQf/uZUssiKcJT0UhmpI5fYjLf9RaYApRrIcF2r7Hc4ICNiMmVwUfeDsB9HEmdN32GOYBfsWcydDU/4ezw=="],
 
     "clean-stack": ["clean-stack@2.2.0", "", {}, "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A=="],
 
@@ -1662,8 +1662,6 @@
     "circuit-json-to-connectivity-map/@tscircuit/math-utils": ["@tscircuit/math-utils@0.0.9", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-sPzfXndijet8z29X6f5vnSZddiso2tRg7m6rB+268bVj60mxnxUMD14rKuMlLn6n84fMOpD/X7pRTZUfi6M+Tg=="],
 
     "circuit-to-svg/@types/node": ["@types/node@22.14.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw=="],
-
-    "circuit-to-svg/bun-types": ["bun-types@1.2.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-Kuh4Ub28ucMRWeiUUWMHsT9Wcbr4H3kLIO72RZZElSDxSu7vpetRvxIUDUaW6QtaIeixIpm7OXtNnZPf82EzwA=="],
 
     "cli-highlight/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@emotion/css": "^11.11.2",
     "@vitejs/plugin-react": "^5.0.2",
-    "circuit-to-svg": "^0.0.166",
+    "circuit-to-svg": "^0.0.191",
     "color": "^4.2.3",
     "react-supergrid": "^1.0.10",
     "react-toastify": "^10.0.5",

--- a/src/examples/polygon-smtpad.fixture.tsx
+++ b/src/examples/polygon-smtpad.fixture.tsx
@@ -1,0 +1,86 @@
+import { PCBViewer } from "../PCBViewer"
+
+// Example showing polygon SMT pad usage
+export const PolygonSmtpadExample = () => {
+  return (
+    <div style={{ backgroundColor: "black" }}>
+      <PCBViewer
+        circuitJson={
+          [
+            {
+              type: "pcb_board",
+              pcb_board_id: "pcb_board_0",
+              center: {
+                x: 0,
+                y: 0,
+              },
+              thickness: 1.4,
+              num_layers: 2,
+              width: 16,
+              height: 8,
+              outline: undefined,
+              material: "fr4",
+            },
+            {
+              type: "pcb_smtpad",
+              pcb_smtpad_id: "pcb_smtpad_0",
+              pcb_component_id: "pcb_component_0",
+              pcb_port_id: "pcb_port_0",
+              layer: "top",
+              shape: "polygon",
+              points: [
+                { x: 2.2, y: 2 },
+                { x: 6, y: 2 },
+                { x: 6, y: -2 },
+                { x: 2.2, y: -2 },
+                { x: 4, y: 0 },
+              ],
+              port_hints: ["pin1"],
+              subcircuit_id: "subcircuit_source_group_0",
+              pcb_group_id: undefined,
+            },
+            {
+              type: "pcb_smtpad",
+              pcb_smtpad_id: "pcb_smtpad_1",
+              pcb_component_id: "pcb_component_0",
+              pcb_port_id: "pcb_port_1",
+              layer: "top",
+              shape: "polygon",
+              points: [
+                { x: -4.5, y: 2 },
+                { x: -2.2, y: 2 },
+                { x: -0.4, y: 0 },
+                { x: -2.2, y: -2 },
+                { x: -4.5, y: -2 },
+              ],
+              port_hints: ["pin2"],
+              subcircuit_id: "subcircuit_source_group_0",
+              pcb_group_id: undefined,
+            },
+            {
+              type: "pcb_smtpad",
+              pcb_smtpad_id: "pcb_smtpad_2",
+              pcb_component_id: "pcb_component_0",
+              pcb_port_id: "pcb_port_2",
+              layer: "top",
+              shape: "polygon",
+              points: [
+                { x: -1.8, y: 2 },
+                { x: 1.8, y: 2 },
+                { x: 3.6, y: 0 },
+                { x: 1.8, y: -2 },
+                { x: -1.8, y: -2 },
+                { x: 0, y: 0 },
+              ],
+              port_hints: ["pin3"],
+              subcircuit_id: "subcircuit_source_group_0",
+              pcb_group_id: undefined,
+            },
+          ] as any
+        }
+      />
+    </div>
+  )
+}
+
+export default PolygonSmtpadExample

--- a/src/lib/convert-element-to-primitive.ts
+++ b/src/lib/convert-element-to-primitive.ts
@@ -159,6 +159,20 @@ export const convertElementToPrimitives = (
             _source_port,
           },
         ]
+      } else if (element.shape === "polygon") {
+        const { layer, points } = element
+        return [
+          {
+            _pcb_drawing_object_id: `polygon_${globalPcbDrawingObjectCount++}`,
+            pcb_drawing_type: "polygon",
+            points,
+            layer: layer || "top",
+            _element: element,
+            _parent_pcb_component,
+            _parent_source_component,
+            _source_port,
+          },
+        ]
       }
       return []
     }


### PR DESCRIPTION
- Implement polygon shape rendering for SMT pads
- Add example fixture demonstrating various polygon pad configurations

/fixes #376 
/claim #376 


<img width="1205" height="490" alt="Screenshot 2025-09-15 at 12 11 34 AM" src="https://github.com/user-attachments/assets/ffb0dd11-9193-4700-b70a-e8b2216d71b9" />
