### PR TITLE
feat: add pill and rotated pill shape support for pcb_smtpad

### DIFF
--- a/src/examples/pill-smtpad.fixture.tsx
+++ b/src/examples/pill-smtpad.fixture.tsx
@@ -1,0 +1,80 @@
+import { PCBViewer } from "../PCBViewer"
+
+// Example showing pill SMT usage
+export const PillSmtpadExample = () => {
+  return (
+    <div style={{ backgroundColor: "black" }}>
+      <PCBViewer
+        circuitJson={
+          [
+            {
+              type: "pcb_board",
+              pcb_board_id: "pcb_board_0",
+              center: {
+                x: 0,
+                y: 0,
+              },
+              thickness: 1.4,
+              num_layers: 2,
+              width: 16,
+              height: 8,
+              outline: undefined,
+              material: "fr4",
+            },
+            {
+              type: "pcb_smtpad",
+              pcb_smtpad_id: "pcb_smtpad_0",
+              pcb_component_id: "pcb_component_0",
+              pcb_port_id: "pcb_port_0",
+              layer: "top",
+              shape: "pill",
+              radius: 0.5,
+              height: 2,
+              width: 1,
+              ccw_rotation: 45,
+              x: 0,
+              y: 0,
+              port_hints: ["pin1"],
+              subcircuit_id: "subcircuit_source_group_0",
+              pcb_group_id: undefined,
+            },
+            {
+              type: "pcb_smtpad",
+              pcb_smtpad_id: "pcb_smtpad_1",
+              pcb_component_id: "pcb_component_0",
+              pcb_port_id: "pcb_port_1",
+              layer: "top",
+              shape: "pill",
+              radius: 1.5,
+              height: 4,
+              width: 2,
+              x: 2,
+              y: 0,
+              port_hints: ["pin2"],
+              subcircuit_id: "subcircuit_source_group_0",
+              pcb_group_id: undefined,
+            },
+            {
+              type: "pcb_smtpad",
+              pcb_smtpad_id: "pcb_smtpad_2",
+              pcb_component_id: "pcb_component_0",
+              pcb_port_id: "pcb_port_2",
+              layer: "top",
+              shape: "pill",
+              radius: 0.5,
+              height: 2,
+              width: 4,
+              x: -3,
+              y: 0,
+              port_hints: ["pin3"],
+              subcircuit_id: "subcircuit_source_group_0",
+              pcb_group_id: undefined,
+            },
+          ] as any
+        }
+      />
+    </div>
+  )
+}
+
+export default PillSmtpadExample

--- a/src/lib/convert-element-to-primitive.ts
+++ b/src/lib/convert-element-to-primitive.ts
@@ -1,4 +1,4 @@
-import type { AnyCircuitElement } from "circuit-json"
+import type { AnyCircuitElement, PcbSmtPadRotatedPill } from "circuit-json"
 import { su } from "@tscircuit/soup-util"
 import type { Primitive } from "./types"
 import { type Point, getExpandedStroke } from "./util/expand-stroke"
@@ -171,6 +171,24 @@ export const convertElementToPrimitives = (
             _parent_pcb_component,
             _parent_source_component,
             _source_port,
+          },
+        ]
+      } else if (element.shape === "pill" || element.shape === "rotated_pill") {
+        const { x, y, width, height, layer } = element
+        return [
+          {
+            _pcb_drawing_object_id: `pill_${globalPcbDrawingObjectCount++}`,
+            pcb_drawing_type: "pill",
+            x,
+            y,
+            w: width,
+            h: height,
+            layer: layer || "top",
+            _element: element,
+            _parent_pcb_component,
+            _parent_source_component,
+            _source_port,
+            ccw_rotation: (element as PcbSmtPadRotatedPill).ccw_rotation,
           },
         ]
       }


### PR DESCRIPTION
- Implement pill shape rendering for SMT pads
- Add example fixture demonstrating various pill pad configurations


<img width="1204" height="492" alt="Screenshot 2025-09-15 at 3 04 30 PM" src="https://github.com/user-attachments/assets/1cc60d0a-5e54-49fe-bd0c-68979207aa87" />
