### PR TITLE
feat: Implement BRep Shape for Copper Pours

### DIFF
--- a/src/examples/copper-pour.fixture.tsx
+++ b/src/examples/copper-pour.fixture.tsx
@@ -8,48 +8,144 @@ export const CopperPour: React.FC = () => {
       type: "pcb_board",
       pcb_board_id: "board1",
       center: { x: 0, y: 0 },
-      width: 50,
-      height: 50,
+      width: 200,
+      height: 100,
       material: "fr4",
       num_layers: 2,
       thickness: 1.6,
     },
+    // pour_brep_1: square with rounded-square hole
     {
       type: "pcb_copper_pour",
-      shape: "rect",
-      pcb_copper_pour_id: "pour1",
+      pcb_copper_pour_id: "pour_brep_1",
       layer: "top",
-      center: { x: -12, y: 12 },
-      width: 10,
-      height: 10,
+      shape: "brep",
+      source_net_id: "net1",
+      brep_shape: {
+        outer_ring: {
+          vertices: [
+            { x: -30, y: 30 },
+            { x: -50, y: 30 },
+            { x: -50, y: 10 },
+            { x: -30, y: 10 },
+          ],
+        },
+        inner_rings: [
+          {
+            vertices: [
+              { x: -35, y: 25, bulge: 0.5 },
+              { x: -45, y: 25 },
+              { x: -45, y: 15 },
+              { x: -35, y: 15 },
+            ],
+          },
+        ],
+      },
     } as PcbCopperPour,
+    // pour_brep_2: Bulgy outer ring, two holes
     {
       type: "pcb_copper_pour",
-      shape: "rect",
-      pcb_copper_pour_id: "pour2",
+      pcb_copper_pour_id: "pour_brep_2",
       layer: "top",
-      center: { x: 12, y: 12 },
-      width: 10,
-      height: 5,
-      rotation: 45,
+      shape: "brep",
+      source_net_id: "net2",
+      brep_shape: {
+        outer_ring: {
+          vertices: [
+            { x: 10, y: 30, bulge: -0.5 },
+            { x: -10, y: 30 },
+            { x: -10, y: 10, bulge: 0.5 },
+            { x: 10, y: 10 },
+          ],
+        },
+        inner_rings: [
+          {
+            // square hole
+            vertices: [
+              { x: -5, y: 25 },
+              { x: -8, y: 25 },
+              { x: -8, y: 22 },
+              { x: -5, y: 22 },
+            ],
+          },
+          {
+            // triangular hole
+            vertices: [
+              { x: 5, y: 25 },
+              { x: 8, y: 22 },
+              { x: 5, y: 22 },
+            ],
+          },
+        ],
+      },
     } as PcbCopperPour,
+    // pour_brep_3: Circular pour with square hole
     {
       type: "pcb_copper_pour",
-      pcb_copper_pour_id: "pour3",
-      shape: "polygon",
+      pcb_copper_pour_id: "pour_brep_3",
+      layer: "top",
+      shape: "brep",
+      source_net_id: "net3",
+      brep_shape: {
+        outer_ring: {
+          vertices: [
+            { x: 30, y: 20, bulge: 1 },
+            { x: 50, y: 20, bulge: 1 },
+          ],
+        },
+        inner_rings: [
+          {
+            vertices: [
+              { x: 38, y: 22 },
+              { x: 42, y: 22 },
+              { x: 42, y: 18 },
+              { x: 38, y: 18 },
+            ],
+          },
+        ],
+      },
+    } as PcbCopperPour,
+    // pour_brep_4: bottom layer pour
+    {
+      type: "pcb_copper_pour",
+      pcb_copper_pour_id: "pour_brep_4",
       layer: "bottom",
+      shape: "brep",
+      source_net_id: "net4",
+      brep_shape: {
+        outer_ring: {
+          vertices: [
+            { x: -30, y: -10 },
+            { x: -50, y: -10 },
+            { x: -50, y: -30 },
+            { x: -30, y: -30, bulge: 0.5 },
+          ],
+        },
+      },
+    } as PcbCopperPour,
+    // pour_rect_1: A rect pour with rotation
+    {
+      type: "pcb_copper_pour",
+      pcb_copper_pour_id: "pour_rect_1",
+      layer: "top",
+      shape: "rect",
+      source_net_id: "net5",
+      center: { x: 0, y: -20 },
+      width: 20,
+      height: 10,
+      rotation: 15,
+    } as PcbCopperPour,
+    // pour_polygon_1: A polygon pour (triangle)
+    {
+      type: "pcb_copper_pour",
+      pcb_copper_pour_id: "pour_polygon_1",
+      layer: "top",
+      shape: "polygon",
+      source_net_id: "net6",
       points: [
-        { x: -2, y: -9 },
-        { x: 2, y: -9 },
-        { x: 2, y: -13 },
-        { x: 6, y: -13 },
-        { x: 6, y: -17 },
-        { x: 2, y: -17 },
-        { x: 2, y: -21 },
-        { x: -2, y: -21 },
-        { x: -6, y: -17 },
-        { x: -6, y: -13 },
-        { x: -2, y: -13 },
+        { x: 30, y: -10 },
+        { x: 50, y: -30 },
+        { x: 30, y: -30 },
       ],
     } as PcbCopperPour,
   ]

--- a/src/lib/convert-element-to-primitive.ts
+++ b/src/lib/convert-element-to-primitive.ts
@@ -694,33 +694,50 @@ export const convertElementToPrimitives = (
     }
     case "pcb_copper_pour": {
       const pour = element as any
+
       switch (pour.shape) {
         case "rect": {
+          const { center, width, height, layer, rotation } = pour
           return [
             {
               _pcb_drawing_object_id: getNewPcbDrawingObjectId(
                 "pcb_copper_pour_rect",
               ),
               pcb_drawing_type: "rect",
-              x: pour.center.x,
-              y: pour.center.y,
-              w: pour.width,
-              h: pour.height,
-              layer: pour.layer,
+              x: center.x,
+              y: center.y,
+              w: width,
+              h: height,
+              layer: layer,
               _element: element,
-              ccw_rotation: pour.rotation,
+              ccw_rotation: rotation,
             },
           ]
         }
         case "polygon": {
+          const { points, layer } = pour
           return [
             {
               _pcb_drawing_object_id: getNewPcbDrawingObjectId(
                 "pcb_copper_pour_polygon",
               ),
               pcb_drawing_type: "polygon",
-              points: pour.points,
-              layer: pour.layer,
+              points: points,
+              layer: layer,
+              _element: element,
+            },
+          ]
+        }
+        case "brep": {
+          const { brep_shape, layer } = pour
+          return [
+            {
+              _pcb_drawing_object_id: getNewPcbDrawingObjectId(
+                "pcb_copper_pour_brep",
+              ),
+              pcb_drawing_type: "polygon_with_arcs",
+              brep_shape: brep_shape,
+              layer: layer,
               _element: element,
             },
           ]

--- a/src/lib/draw-primitives.ts
+++ b/src/lib/draw-primitives.ts
@@ -8,6 +8,7 @@ import type {
   Oval,
   Pill,
   Polygon,
+  PolygonWithArcs,
   Primitive,
   Rect,
   Text,
@@ -215,17 +216,26 @@ export const drawPolygon = (drawer: Drawer, polygon: Polygon) => {
   drawer.polygon(polygon.points)
 }
 
+export const drawPolygonWithArcs = (drawer: Drawer, p: PolygonWithArcs) => {
+  drawer.equip({
+    color: getColor(p),
+    layer: p.layer,
+  })
+  drawer.polygonWithArcs(p.brep_shape)
+}
+
 export const drawPrimitive = (drawer: Drawer, primitive: Primitive) => {
   switch (primitive.pcb_drawing_type) {
     case "line":
       return drawLine(drawer, primitive)
     case "text":
       return drawText(drawer, primitive)
-    case "rect":
+    case "rect": {
       if (primitive.ccw_rotation) {
         return drawRotatedRect(drawer, primitive)
       }
       return drawRect(drawer, primitive)
+    }
     case "circle":
       return drawCircle(drawer, primitive)
     case "oval":
@@ -237,6 +247,8 @@ export const drawPrimitive = (drawer: Drawer, primitive: Primitive) => {
       return drawPill(drawer, primitive)
     case "polygon":
       return drawPolygon(drawer, primitive)
+    case "polygon_with_arcs":
+      return drawPolygonWithArcs(drawer, primitive)
   }
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,25 @@
 import type { AnyCircuitElement } from "circuit-json"
 
+export interface PointWithBulge {
+  x: number
+  y: number
+  bulge?: number
+}
+
+export interface Ring {
+  vertices: PointWithBulge[]
+}
+
+export interface BRepShape {
+  outer_ring: Ring
+  inner_rings?: Ring[]
+}
+
+export interface PolygonWithArcs extends PCBDrawingObject {
+  pcb_drawing_type: "polygon_with_arcs"
+  brep_shape: BRepShape
+}
+
 export type AlignString =
   | "top_left"
   | "top_center"
@@ -94,7 +114,15 @@ export interface Polygon extends PCBDrawingObject {
   points: { x: number; y: number }[]
 }
 
-export type Primitive = Line | Text | Rect | Circle | Oval | Pill | Polygon
+export type Primitive =
+  | Line
+  | Text
+  | Rect
+  | Circle
+  | Oval
+  | Pill
+  | Polygon
+  | PolygonWithArcs
 
 export type GridConfig = {
   spacing: number


### PR DESCRIPTION
This pull request introduces support for rendering copper pour shapes using Boundary Representation (BRep). This allows for pours with curved edges (arcs) and internal holes.                                                    

 • New brep shape for pcb_copper_pour: Copper pours can now be defined with shape: "brep", which uses an outer_ring and optional inner_rings to describe complex boundaries. Each vertex in a ring can have a bulge property to define a curved segment.                                       
 • polygon_with_arcs Primitive: A new primitive type, polygon_with_arcs, was added to represent BRep shapes in the rendering pipeline.            
 • Drawer Implementation: The Drawer class now includes a polygonWithArcs method that:                                                            
    • Iterates through the vertices of the outer and inner rings.                                                                                 
    • Calculates arc geometry (center, radius, start/end angles) from the bulge value between two vertices.                                       
    • Constructs the path using lineTo for straight segments and arc for curved segments.                                                         
    • Uses the evenodd fill rule to correctly render polygons with holes.  
    
<img width="1002" height="439" alt="image" src="https://github.com/user-attachments/assets/283edb43-779a-4b26-b778-7307406d7b70" />
