### PR TITLE
Skip hover overlay when hover label is empty

### DIFF
--- a/src/components/ElementOverlayBox.tsx
+++ b/src/components/ElementOverlayBox.tsx
@@ -183,6 +183,11 @@ export const HighlightedPrimitiveBoxWithText = ({
     )
   }
 
+  const label = getTextForHighlightedPrimitive(primitive)
+  if (label.trim().length === 0) {
+    return null
+  }
+
   return (
     <div
       style={{
@@ -233,7 +238,7 @@ export const HighlightedPrimitiveBoxWithText = ({
             textAlign: "center",
           }}
         >
-          {getTextForHighlightedPrimitive(primitive)}
+          {label}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- avoid rendering hover overlays when the generated label text is empty to prevent blank hovers

## Testing
- bunx tsc --noEmit
- bun test

------
https://chatgpt.com/codex/tasks/task_b_68f7f33959dc832e92d6a7002d97434a