### PR TITLE
feat: Add PCB panel support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@emotion/css": "^11.11.2",
         "@tscircuit/alphabet": "^0.0.3",
         "@vitejs/plugin-react": "^5.0.2",
-        "circuit-json": "^0.0.282",
+        "circuit-json": "^0.0.295",
         "circuit-to-svg": "^0.0.240",
         "color": "^4.2.3",
         "react-supergrid": "^1.0.10",
@@ -595,7 +595,7 @@
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
-    "circuit-json": ["circuit-json@0.0.282", "", {}, "sha512-sj3rYwQqVB1OfUSuKqRliLoN9JTBFOpR147HXsYlbndq8BQNgSj9+1uHklDLBEbaxZsvxGkP0masaylChQBGWA=="],
+    "circuit-json": ["circuit-json@0.0.295", "", {}, "sha512-vARRbZcTE09JhhRZF5tAwjbQbmTBZ3Z6U4H4PSYBazlWyidPNQcG+sd2kg7xqdGvwznxZ2GDdTSbtyG5O0/aog=="],
 
     "circuit-json-to-bpc": ["circuit-json-to-bpc@0.0.13", "", { "peerDependencies": { "bpc-graph": "*", "circuit-json": "*", "typescript": "^5" } }, "sha512-3wSMtPa6tJkiBQN4tsm7f0Mb7Wp90X2c8dNbULoDVE4mGGoFqP1DXqBlyvvZZl+4SjqznzQQ0EioLe2SCQTOcg=="],
 
@@ -1133,7 +1133,7 @@
 
     "nano-css": ["nano-css@5.6.2", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15", "css-tree": "^1.1.2", "csstype": "^3.1.2", "fastest-stable-stringify": "^2.0.2", "inline-style-prefixer": "^7.0.1", "rtl-css-js": "^1.16.1", "stacktrace-js": "^2.0.2", "stylis": "^4.3.0" }, "peerDependencies": { "react": "*", "react-dom": "*" } }, "sha512-+6bHaC8dSDGALM1HJjOHVXpuastdu2xFoZlC77Jh4cg+33Zcgm+Gxd+1xsnpZK14eyHObSp82+ll5y3SX75liw=="],
 
-    "nanoid": ["nanoid@5.1.5", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw=="],
+    "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
 
@@ -1679,6 +1679,8 @@
 
     "@tscircuit/circuit-json-flex/@tscircuit/miniflex": ["@tscircuit/miniflex@0.0.3", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-oRC0up2psp8dJD1CzXyUiFuhQZUWLdZNl9EAqOf/hHqXDhPKMU6wM79S+XQuaB0gdWNRnwcURHPPaKLw/ka3DQ=="],
 
+    "@tscircuit/core/nanoid": ["nanoid@5.1.5", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw=="],
+
     "@tscircuit/core/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@tscircuit/footprinter/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
@@ -2201,8 +2203,6 @@
 
     "pkg-conf/find-up": ["find-up@2.1.0", "", { "dependencies": { "locate-path": "^2.0.0" } }, "sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ=="],
 
-    "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
-
     "prebuild-install/tar-fs": ["tar-fs@2.1.2", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA=="],
 
     "read-package-up/read-pkg": ["read-pkg@9.0.1", "", { "dependencies": { "@types/normalize-package-data": "^2.4.3", "normalize-package-data": "^6.0.0", "parse-json": "^8.0.0", "type-fest": "^4.6.0", "unicorn-magic": "^0.1.0" } }, "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA=="],
@@ -2482,8 +2482,6 @@
     "tscircuit/circuit-to-svg/@types/node": ["@types/node@22.14.1", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw=="],
 
     "tsup/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
-
-    "vite/postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "@babel/helper-module-imports/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.25.9", "", {}, "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ=="],
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@emotion/css": "^11.11.2",
     "@tscircuit/alphabet": "^0.0.3",
     "@vitejs/plugin-react": "^5.0.2",
-    "circuit-json": "^0.0.282",
+    "circuit-json": "^0.0.295",
     "circuit-to-svg": "^0.0.240",
     "color": "^4.2.3",
     "react-supergrid": "^1.0.10",

--- a/src/examples/pcb-panel.fixture.tsx
+++ b/src/examples/pcb-panel.fixture.tsx
@@ -1,0 +1,43 @@
+import { PCBViewer } from "../PCBViewer"
+
+export const PcbPanelExample = () => {
+  return (
+    <div style={{ backgroundColor: "black" }}>
+      <PCBViewer
+        circuitJson={[
+          {
+            type: "pcb_panel",
+            pcb_panel_id: "pcb_panel_0",
+            width: 80,
+            height: 60,
+            covered_with_solder_mask: false,
+          },
+          {
+            type: "pcb_board",
+            pcb_board_id: "pcb_board_0",
+            center: { x: 40, y: 30 },
+            width: 40,
+            height: 20,
+            material: "fr4",
+            num_layers: 2,
+            thickness: 1.6,
+          },
+          {
+            type: "pcb_smtpad",
+            pcb_smtpad_id: "pcb_smtpad_0",
+            layer: "top",
+            shape: "rect",
+            x: 40,
+            y: 30,
+            width: 4,
+            height: 3,
+          },
+        ]}
+      />
+    </div>
+  )
+}
+
+export default {
+  PcbPanelExample,
+}

--- a/src/lib/convert-element-to-primitive.ts
+++ b/src/lib/convert-element-to-primitive.ts
@@ -6,6 +6,7 @@ import type {
   PcbNoteText,
   PcbNoteDimension,
   PcbSmtPadRotatedPill,
+  PcbPanel,
 } from "circuit-json"
 import { su } from "@tscircuit/circuit-json-util"
 import type { Primitive } from "./types"
@@ -66,6 +67,59 @@ export const convertElementToPrimitives = (
     : undefined
 
   switch (element.type) {
+    case "pcb_panel": {
+      const { width, height } = element as PcbPanel
+      return [
+        {
+          _pcb_drawing_object_id: `line_${globalPcbDrawingObjectCount++}`,
+          pcb_drawing_type: "line",
+          x1: 0,
+          y1: 0,
+          x2: width,
+          y2: 0,
+          width: 1,
+          zoomIndependent: true,
+          layer: "board",
+          _element: element,
+        },
+        {
+          _pcb_drawing_object_id: `line_${globalPcbDrawingObjectCount++}`,
+          pcb_drawing_type: "line",
+          x1: 0,
+          y1: height,
+          x2: width,
+          y2: height,
+          width: 1,
+          zoomIndependent: true,
+          layer: "board",
+          _element: element,
+        },
+        {
+          _pcb_drawing_object_id: `line_${globalPcbDrawingObjectCount++}`,
+          pcb_drawing_type: "line",
+          x1: 0,
+          y1: 0,
+          x2: 0,
+          y2: height,
+          width: 1,
+          zoomIndependent: true,
+          layer: "board",
+          _element: element,
+        },
+        {
+          _pcb_drawing_object_id: `line_${globalPcbDrawingObjectCount++}`,
+          pcb_drawing_type: "line",
+          x1: width,
+          y1: 0,
+          x2: width,
+          y2: height,
+          width: 1,
+          zoomIndependent: true,
+          layer: "board",
+          _element: element,
+        },
+      ]
+    }
     case "pcb_board": {
       const { width, height, center, outline } = element
 
@@ -1116,7 +1170,7 @@ export const convertElementToPrimitives = (
           y: noteTextElement.anchor_position.y,
           layer: "notes",
           align: noteTextElement.anchor_alignment ?? "center",
-          text: noteTextElement.text,
+          text: noteTextElement.text || "",
           size: noteTextElement.font_size,
           color: noteTextElement.color,
           _element: element,


### PR DESCRIPTION
This pull request introduces support for rendering pcb_panel elements in the PCB viewer.                                                            

 • Updates the circuit-json dependency to include the PcbPanel type.                                                                                
 • Modifies convert-element-to-primitive.ts to handle pcb_panel elements by drawing their outline.                                                  
 • Adds src/examples/pcb-panel.fixture.tsx to demonstrate and test the new functionality.     
                                                      
<img width="1100" height="632" alt="Screenshot 2025-10-27 at 5 38 17 PM" src="https://github.com/user-attachments/assets/d0743874-0dff-44db-821b-6296672cb11b" />
