### PR TITLE
Add toggle to hide copper pours from view menu

### DIFF
--- a/src/components/CanvasElementsRenderer.tsx
+++ b/src/components/CanvasElementsRenderer.tsx
@@ -37,17 +37,28 @@ export interface CanvasElementsRendererProps {
 export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
   const { transform, elements } = props
   const hoveredErrorId = useGlobalStore((state) => state.hovered_error_id)
+  const isShowingCopperPours = useGlobalStore(
+    (state) => state.is_showing_copper_pours,
+  )
+
+  const elementsToRender = useMemo(
+    () =>
+      isShowingCopperPours
+        ? elements
+        : elements.filter((elm) => elm.type !== "pcb_copper_pour"),
+    [elements, isShowingCopperPours],
+  )
 
   const [primitivesWithoutInteractionMetadata, connectivityMap] =
     useMemo(() => {
-      const primitivesWithoutInteractionMetadata = props.elements.flatMap(
+      const primitivesWithoutInteractionMetadata = elementsToRender.flatMap(
         (elm) => convertElementToPrimitives(elm, props.elements),
       )
       const connectivityMap = getFullConnectivityMapFromCircuitJson(
         props.elements as any,
       )
       return [primitivesWithoutInteractionMetadata, connectivityMap]
-    }, [props.elements])
+    }, [elementsToRender, props.elements])
 
   const [hoverState, setHoverState] = useState({
     drawingObjectIdsWithMouseOver: new Set<string>(),
@@ -128,7 +139,7 @@ export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
 
   return (
     <MouseElementTracker
-      elements={elements}
+      elements={elementsToRender}
       transform={transform}
       primitives={primitivesWithoutInteractionMetadata}
       onMouseHoverOverPrimitives={onMouseOverPrimitives}

--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -198,6 +198,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     setIsShowingMultipleTracesLength,
     setIsShowingAutorouting,
     setIsShowingDrcErrors,
+    setIsShowingCopperPours,
     setIsShowingPcbGroups,
     setPcbGroupViewMode,
     setHoveredErrorId,
@@ -215,6 +216,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
       is_showing_multiple_traces_length: s.is_showing_multiple_traces_length,
       is_showing_autorouting: s.is_showing_autorouting,
       is_showing_drc_errors: s.is_showing_drc_errors,
+      is_showing_copper_pours: s.is_showing_copper_pours,
       is_showing_pcb_groups: s.is_showing_pcb_groups,
       pcb_group_view_mode: s.pcb_group_view_mode,
     },
@@ -223,6 +225,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     setIsShowingMultipleTracesLength: s.setIsShowingMultipleTracesLength,
     setIsShowingAutorouting: s.setIsShowingAutorouting,
     setIsShowingDrcErrors: s.setIsShowingDrcErrors,
+    setIsShowingCopperPours: s.setIsShowingCopperPours,
     setIsShowingPcbGroups: s.setIsShowingPcbGroups,
     setPcbGroupViewMode: s.setPcbGroupViewMode,
     setHoveredErrorId: s.setHoveredErrorId,
@@ -695,6 +698,15 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
                   checked={viewSettings.is_showing_drc_errors}
                   onClick={() => {
                     setIsShowingDrcErrors(!viewSettings.is_showing_drc_errors)
+                  }}
+                />
+                <CheckboxMenuItem
+                  label="Show Copper Pours"
+                  checked={viewSettings.is_showing_copper_pours}
+                  onClick={() => {
+                    setIsShowingCopperPours(
+                      !viewSettings.is_showing_copper_pours,
+                    )
                   }}
                 />
                 <CheckboxMenuItem

--- a/src/global-store.ts
+++ b/src/global-store.ts
@@ -30,6 +30,7 @@ export interface State {
 
   is_showing_multiple_traces_length: boolean
   is_showing_rats_nest: boolean
+  is_showing_copper_pours: boolean
   is_showing_pcb_groups: boolean
   pcb_group_view_mode: "all" | "named_only"
 
@@ -44,6 +45,7 @@ export interface State {
   setIsShowingAutorouting: (is_showing: boolean) => void
   setIsShowingMultipleTracesLength: (is_showing: boolean) => void
   setIsShowingDrcErrors: (is_showing: boolean) => void
+  setIsShowingCopperPours: (is_showing: boolean) => void
   setIsShowingPcbGroups: (is_showing: boolean) => void
   setPcbGroupViewMode: (mode: "all" | "named_only") => void
   setHoveredErrorId: (errorId: string | null) => void
@@ -79,6 +81,7 @@ export const createStore = (
         is_showing_rats_nest: false,
         is_showing_autorouting: true,
         is_showing_drc_errors: true,
+        is_showing_copper_pours: true,
         is_showing_pcb_groups: disablePcbGroups
           ? false
           : getStoredBoolean(STORAGE_KEYS.IS_SHOWING_PCB_GROUPS, true),
@@ -115,6 +118,8 @@ export const createStore = (
           set({ is_showing_autorouting: is_showing }),
         setIsShowingDrcErrors: (is_showing) =>
           set({ is_showing_drc_errors: is_showing }),
+        setIsShowingCopperPours: (is_showing) =>
+          set({ is_showing_copper_pours: is_showing }),
         setIsShowingPcbGroups: (is_showing) => {
           if (disablePcbGroups) return
           setStoredBoolean(STORAGE_KEYS.IS_SHOWING_PCB_GROUPS, is_showing)


### PR DESCRIPTION
## Summary
- add a global view setting for copper pours
- expose a "Show Copper Pours" toggle in the View menu
- filter copper pour primitives when the toggle is disabled

## Testing
- bunx tsc --noEmit
- bun run format

------
https://chatgpt.com/codex/tasks/task_b_69015a5a3ad4832e9af0a360f54b0dab