### PR TITLE
Add option to hide copper pours and save to local storage

### DIFF
--- a/src/global-store.ts
+++ b/src/global-store.ts
@@ -81,7 +81,10 @@ export const createStore = (
         is_showing_rats_nest: false,
         is_showing_autorouting: true,
         is_showing_drc_errors: true,
-        is_showing_copper_pours: true,
+        is_showing_copper_pours: getStoredBoolean(
+          STORAGE_KEYS.IS_SHOWING_COPPER_POURS,
+          true,
+        ),
         is_showing_pcb_groups: disablePcbGroups
           ? false
           : getStoredBoolean(STORAGE_KEYS.IS_SHOWING_PCB_GROUPS, true),
@@ -118,8 +121,10 @@ export const createStore = (
           set({ is_showing_autorouting: is_showing }),
         setIsShowingDrcErrors: (is_showing) =>
           set({ is_showing_drc_errors: is_showing }),
-        setIsShowingCopperPours: (is_showing) =>
-          set({ is_showing_copper_pours: is_showing }),
+        setIsShowingCopperPours: (is_showing) => {
+          setStoredBoolean(STORAGE_KEYS.IS_SHOWING_COPPER_POURS, is_showing)
+          set({ is_showing_copper_pours: is_showing })
+        },
         setIsShowingPcbGroups: (is_showing) => {
           if (disablePcbGroups) return
           setStoredBoolean(STORAGE_KEYS.IS_SHOWING_PCB_GROUPS, is_showing)

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -3,6 +3,7 @@ import { useCallback } from "react"
 export const STORAGE_KEYS = {
   IS_SHOWING_PCB_GROUPS: "pcb_viewer_is_showing_pcb_groups",
   PCB_GROUP_VIEW_MODE: "pcb_viewer_group_view_mode",
+  IS_SHOWING_COPPER_POURS: "pcb_viewer_is_showing_copper_pours",
 } as const
 
 export const getStoredBoolean = (


### PR DESCRIPTION
This pull request introduces a new option in the "View" dropdown menu to show or hide copper   
pours. The visibility state is persisted in local storage, so the user's preference is         
remembered across sessions.
<img width="1031" height="691" alt="Screenshot 2025-10-29 at 4 47 01 PM" src="https://github.com/user-attachments/assets/d1f0b6d5-44a5-4d08-8f5d-baebff02382f" />
<img width="1106" height="739" alt="Screenshot 2025-10-29 at 4 47 21 PM" src="https://github.com/user-attachments/assets/9742fe1b-ee9f-43dd-9759-11a845989d62" />
