### PR TITLE
Fix multi-layer visibility issues: inner5,6 not showing and top layer…

### DIFF
--- a/src/examples/multi-layer/eight-layer-circuit.fixture.tsx
+++ b/src/examples/multi-layer/eight-layer-circuit.fixture.tsx
@@ -1,0 +1,130 @@
+import { PCBViewer } from "../../PCBViewer"
+import type { AnyCircuitElement } from "circuit-json"
+
+const EightLayerCircuit = () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "pcb_board_0",
+      center: { x: 0, y: 0 },
+      width: 60,
+      height: 25,
+      material: "fr4",
+      num_layers: 8,
+      thickness: 1.6,
+    },
+    // Single pad on top layer
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_top",
+      x: -21,
+      y: 0,
+      width: 2,
+      height: 1,
+      layer: "top",
+      shape: "rect",
+    },
+    // Single pad on inner1 layer
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_inner1",
+      x: -15,
+      y: 0,
+      width: 2,
+      height: 1,
+      layer: "inner1",
+      shape: "rect",
+    },
+    // Single pad on inner2 layer
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_inner2",
+      x: -9,
+      y: 0,
+      width: 2,
+      height: 1,
+      layer: "inner2",
+      shape: "rect",
+    },
+    // Single pad on inner3 layer
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_inner3",
+      x: -3,
+      y: 0,
+      width: 2,
+      height: 1,
+      layer: "inner3",
+      shape: "rect",
+    },
+    // Single pad on inner4 layer
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_inner4",
+      x: 3,
+      y: 0,
+      width: 2,
+      height: 1,
+      layer: "inner4",
+      shape: "rect",
+    },
+    // Single pad on inner5 layer
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_inner5",
+      x: 9,
+      y: 0,
+      width: 2,
+      height: 1,
+      layer: "inner5",
+      shape: "rect",
+    },
+    // Single pad on inner6 layer
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_inner6",
+      x: 15,
+      y: 0,
+      width: 2,
+      height: 1,
+      layer: "inner6",
+      shape: "rect",
+    },
+    // Single pad on bottom layer
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_bottom",
+      x: 21,
+      y: 0,
+      width: 2,
+      height: 1,
+      layer: "bottom",
+      shape: "rect",
+    },
+  ]
+
+  return (
+    <div style={{ backgroundColor: "black" }}>
+      <div style={{ marginBottom: "20px", color: "white", padding: "20px" }}>
+        <h3>8-Layer Circuit - Simple Layout</h3>
+        <p>
+          This circuit has 8 layers with one pad per layer, all side by side
+        </p>
+        <p style={{ fontSize: "14px", opacity: 0.8 }}>
+          Expected layer dropdown: [top, inner1, inner2, inner3, inner4, inner5,
+          inner6, bottom]
+        </p>
+        <p style={{ fontSize: "14px", opacity: 0.8 }}>
+          Layout: TOP | I1 | I2 | I3 | I4 | I5 | I6 | BOTTOM
+        </p>
+        <p style={{ fontSize: "14px", opacity: 0.8, marginTop: "10px" }}>
+          This tests the maximum layer count (8 layers) with all hotkeys 1-8
+          working
+        </p>
+      </div>
+      <PCBViewer circuitJson={circuitJson} />
+    </div>
+  )
+}
+
+export default EightLayerCircuit

--- a/src/examples/multi-layer/overlapping-layers-test.fixture.tsx
+++ b/src/examples/multi-layer/overlapping-layers-test.fixture.tsx
@@ -1,0 +1,138 @@
+import { PCBViewer } from "../../PCBViewer"
+import type { AnyCircuitElement } from "circuit-json"
+
+const OverlappingLayersTest = () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "pcb_board_0",
+      center: { x: 0, y: 0 },
+      width: 30,
+      height: 20,
+      material: "fr4",
+      num_layers: 8,
+      thickness: 1.6,
+    },
+    // All pads at the SAME position to test z-index stacking
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_top",
+      x: 0,
+      y: 0,
+      width: 5,
+      height: 5,
+      layer: "top",
+      shape: "rect",
+    },
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_inner1",
+      x: 0,
+      y: 0,
+      width: 4.5,
+      height: 4.5,
+      layer: "inner1",
+      shape: "rect",
+    },
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_inner2",
+      x: 0,
+      y: 0,
+      width: 4,
+      height: 4,
+      layer: "inner2",
+      shape: "rect",
+    },
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_inner3",
+      x: 0,
+      y: 0,
+      width: 3.5,
+      height: 3.5,
+      layer: "inner3",
+      shape: "rect",
+    },
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_inner4",
+      x: 0,
+      y: 0,
+      width: 3,
+      height: 3,
+      layer: "inner4",
+      shape: "rect",
+    },
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_inner5",
+      x: 0,
+      y: 0,
+      width: 2.5,
+      height: 2.5,
+      layer: "inner5",
+      shape: "rect",
+    },
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_inner6",
+      x: 0,
+      y: 0,
+      width: 2,
+      height: 2,
+      layer: "inner6",
+      shape: "rect",
+    },
+    {
+      type: "pcb_smtpad",
+      pcb_smtpad_id: "pcb_smtpad_bottom",
+      x: 0,
+      y: 0,
+      width: 1.5,
+      height: 1.5,
+      layer: "bottom",
+      shape: "rect",
+    },
+  ]
+
+  return (
+    <div style={{ backgroundColor: "black" }}>
+      <div style={{ marginBottom: "20px", color: "white", padding: "20px" }}>
+        <h3>Overlapping Layers Z-Index Test</h3>
+        <p>
+          All 8 layers have pads at the SAME position (0, 0) with decreasing
+          sizes
+        </p>
+        <p style={{ fontSize: "14px", opacity: 0.8, marginTop: "10px" }}>
+          <strong>How to verify:</strong>
+        </p>
+        <ul style={{ fontSize: "14px", opacity: 0.8, marginLeft: "20px" }}>
+          <li>
+            Select "top" layer - You should see the RED top pad (largest) fully
+            opaque on top
+          </li>
+          <li>
+            Select "inner1" - You should see the GREEN inner1 pad fully opaque
+            on top
+          </li>
+          <li>
+            Select "inner2" - You should see the ORANGE inner2 pad fully opaque
+            on top
+          </li>
+          <li>
+            Continue testing each layer - the selected layer should ALWAYS be on
+            top
+          </li>
+          <li>All other layers should be visible at 50% opacity beneath</li>
+        </ul>
+        <p style={{ fontSize: "14px", opacity: 0.8, marginTop: "10px" }}>
+          Use hotkeys 1-8 or the layer dropdown to switch between layers
+        </p>
+      </div>
+      <PCBViewer circuitJson={circuitJson} />
+    </div>
+  )
+}
+
+export default OverlappingLayersTest

--- a/src/lib/Drawer.ts
+++ b/src/lib/Drawer.ts
@@ -36,7 +36,7 @@ export const LAYER_NAME_TO_COLOR = {
   top: colors.board.copper.f,
   inner1: colors.board.copper.in1,
   inner2: colors.board.copper.in2,
-
+  inner3: colors.board.copper.in3,
   inner4: colors.board.copper.in4,
   inner5: colors.board.copper.in5,
   inner6: colors.board.copper.in6,
@@ -64,16 +64,16 @@ export type LayerNameForColor = keyof typeof LAYER_NAME_TO_COLOR
 
 export const DEFAULT_DRAW_ORDER = [
   "board",
+  "inner6",
+  "inner5",
+  "inner4",
+  "inner3",
+  "inner2",
+  "inner1",
+  "bottom",
+  "bottom_silkscreen",
   "top",
   "top_silkscreen",
-  "bottom_silkscreen",
-  "bottom",
-  "inner1",
-  "inner2",
-  "inner3",
-  "inner4",
-  "inner5",
-  "inner6",
 ] as const
 
 export const FILL_TYPES = {
@@ -490,22 +490,29 @@ export class Drawer {
           ? "bottom_silkscreen"
           : "",
     ])
+
+    // Build order with foregroundLayer at the end (highest z-index)
     const order = [
-      "drill",
       "board",
-      foregroundLayer,
+      "drill",
       ...DEFAULT_DRAW_ORDER.filter((l) => l !== foregroundLayer),
+      foregroundLayer,
     ]
+
     order.forEach((layer, i) => {
       const canvas = canvasLayerMap[layer]
       if (!canvas) return
-      if (
+
+      // Foreground layer and its associated silkscreen get the highest z-index
+      if (layer === foregroundLayer) {
+        canvas.style.zIndex = `${zIndexMap.topLayer}`
+      } else if (
         (layer === "bottom_silkscreen" && foregroundLayer === "bottom") ||
         (layer === "top_silkscreen" && foregroundLayer === "top")
       ) {
-        canvas.style.zIndex = `${zIndexMap.topLayer}` // zIndexMap.topLayer
+        canvas.style.zIndex = `${zIndexMap.topLayer + 1}`
       } else {
-        canvas.style.zIndex = `${zIndexMap.topLayer - i}`
+        canvas.style.zIndex = `${zIndexMap.topLayer - (order.length - i)}`
       }
       canvas.style.opacity = opaqueLayers.has(layer) ? "1" : "0.5"
     })


### PR DESCRIPTION

https://github.com/user-attachments/assets/2460589c-7054-439b-abf3-870490fe9708


## Issue Summary
The 8-layer PCB viewer had two critical visibility problems: (1) inner layers 5 and 6 weren't displaying when viewing the top layer by default, and (2) the top layer would completely disappear when any other layer was selected. The root cause was threefold: a missing inner3 color mapping in LAYER_NAME_TO_COLOR, an incorrect DEFAULT_DRAW_ORDER that placed inner layers at the end causing them to render with the lowest z-index values, and a flawed orderAndFadeLayers() function that positioned the selected foreground layer early in the rendering order instead of on top.

## Changes Made
I fixed the color mapping by adding the missing inner3 entry, reordered DEFAULT_DRAW_ORDER to properly stack layers from bottom-to-top (board → inner6 through inner1 → bottom → top), and restructured orderAndFadeLayers() to place the foreground layer at the end of the order array so it always receives the highest z-index. I also added proper TypeScript typing to the eight-layer fixture and created a new overlapping-layers-test fixture with all pads at the same position to visually verify that the selected layer always appears on top with full opacity while other layers remain visible at 50% opacity beneath it. These changes ensure all 8 layers are visible and the selected layer always has the highest z-index for proper stacking behavior.

## New Files Created
eight-layer-circuit.fixture.tsx: This fixture was created to properly test the maximum 8-layer PCB configuration with correct TypeScript typing using AnyCircuitElement[]. It places one pad per layer side-by-side to verify that all layers (top, inner1-6, bottom) are visible in the layer dropdown and render correctly when selected individually or when viewing the top layer by default.

overlapping-layers-test.fixture.tsx: This specialized test fixture was created to definitively verify the z-index stacking fix by placing all 8 layers' pads at the exact same position (0, 0) with decreasing sizes, creating a visual "bullseye" effect. This makes it immediately obvious which layer is rendered on top when selected, allowing developers to quickly verify that the selected layer always appears fully opaque with the highest z-index while all other layers remain visible at 50% opacity beneath it.



fixes #398