### PR TITLE
Fix: Ensure drill and foreground layers render on top 

### DIFF
--- a/src/examples/hole.fixture.tsx
+++ b/src/examples/hole.fixture.tsx
@@ -13,6 +13,7 @@ export const HoleExample: React.FC = () => {
           <footprint>
             {/* @ts-ignore */}
             <hole pcbX="2mm" pcbY="0mm" diameter="1mm" />
+            <hole pcbX="-2mm" pcbY="-2mm" diameter="1mm" />
             <smtpad
               portHints={["1"]}
               pcbX="0mm"

--- a/src/lib/Drawer.ts
+++ b/src/lib/Drawer.ts
@@ -491,29 +491,32 @@ export class Drawer {
           : "",
     ])
 
-    // Build order with foregroundLayer at the end (highest z-index)
-    const order = [
-      "board",
-      "drill",
-      ...DEFAULT_DRAW_ORDER.filter((l) => l !== foregroundLayer),
+    const associatedSilkscreen =
+      foregroundLayer === "top"
+        ? "top_silkscreen"
+        : foregroundLayer === "bottom"
+          ? "bottom_silkscreen"
+          : undefined
+
+    const layersToShiftToTop = [
       foregroundLayer,
+      ...(associatedSilkscreen ? [associatedSilkscreen] : []),
+    ]
+
+    const order = [
+      ...DEFAULT_DRAW_ORDER.filter(
+        (l) => !layersToShiftToTop.includes(l as any),
+      ),
+      foregroundLayer,
+      "drill",
+      ...(associatedSilkscreen ? [associatedSilkscreen] : []),
     ]
 
     order.forEach((layer, i) => {
       const canvas = canvasLayerMap[layer]
       if (!canvas) return
 
-      // Foreground layer and its associated silkscreen get the highest z-index
-      if (layer === foregroundLayer) {
-        canvas.style.zIndex = `${zIndexMap.topLayer}`
-      } else if (
-        (layer === "bottom_silkscreen" && foregroundLayer === "bottom") ||
-        (layer === "top_silkscreen" && foregroundLayer === "top")
-      ) {
-        canvas.style.zIndex = `${zIndexMap.topLayer + 1}`
-      } else {
-        canvas.style.zIndex = `${zIndexMap.topLayer - (order.length - i)}`
-      }
+      canvas.style.zIndex = `${zIndexMap.topLayer - (order.length - i)}`
       canvas.style.opacity = opaqueLayers.has(layer) ? "1" : "0.5"
     })
   }


### PR DESCRIPTION
Refactored the orderAndFadeLayers method to simplify layer z-index management and ensure       
correct rendering order.                                                                       

Previously, zIndex was calculated using complex conditional logic. This has been simplified to 
derive the zIndex directly from the layer's position in the order array. The foreground layer, 
its associated silkscreen, and the drill layer are now consistently moved to the end of the    
rendering order to ensure they always appear on top.

<img width="1113" height="695" alt="Screenshot 2025-10-30 at 10 53 09 PM" src="https://github.com/user-attachments/assets/84b96697-81d5-4086-befa-8d32cc88126e" />
