### PR TITLE
Add Bottom-Layer Support for plated hole Rectangular Pad Primitives

### DIFF
--- a/src/lib/convert-element-to-primitive.ts
+++ b/src/lib/convert-element-to-primitive.ts
@@ -440,7 +440,7 @@ export const convertElementToPrimitives = (
             y,
             w: rect_pad_width,
             h: rect_pad_height,
-            layer: "bottom", // Rectangular pad on top layer
+            layer: "bottom", // Rectangular pad on bottom layer
             _element: element,
             _parent_pcb_component,
             _parent_source_component,
@@ -490,7 +490,7 @@ export const convertElementToPrimitives = (
             y,
             w: rect_pad_width,
             h: rect_pad_height,
-            layer: "bottom", // Rectangular pad on top layer
+            layer: "bottom", // Rectangular pad on bottom layer
             _element: element,
             _parent_pcb_component,
             _parent_source_component,
@@ -544,7 +544,7 @@ export const convertElementToPrimitives = (
             y,
             w: rect_pad_width,
             h: rect_pad_height,
-            layer: "bottom", // Rectangular pad on top layer
+            layer: "bottom", // Rectangular pad on bottom layer
             _element: element,
             _parent_pcb_component,
             _parent_source_component,


### PR DESCRIPTION
This PR adds a matching rectangular primitive on the bottom copper layer for all plated hole rectangular pad types. The top-layer pad logic is preserved