### PR TITLE
fix: offset dimension text perpendicular to dimension line

### DIFF
--- a/src/lib/convert-element-to-primitive.ts
+++ b/src/lib/convert-element-to-primitive.ts
@@ -1118,8 +1118,18 @@ export const convertElementToPrimitives = (
         const baseOffset = (font_size ?? 1) * 1.5
         const perpX = -unitY
         const perpY = unitX
-        const textOffset =
-          Math.abs(unitX) > Math.abs(unitY) ? baseOffset : -baseOffset
+        const midpointX = (from.x + to.x) / 2
+        const midpointY = (from.y + to.y) / 2
+
+        // Determine offset direction based on which side of board the dimension is on
+        let textOffset = baseOffset
+        if (Math.abs(unitX) > Math.abs(unitY)) {
+          // Horizontal dimension: offset based on y position
+          textOffset = midpointY >= 0 ? baseOffset : -baseOffset
+        } else {
+          // Vertical dimension: offset based on x position
+          textOffset = midpointX >= 0 ? -baseOffset : baseOffset
+        }
 
         primitives.push({
           _pcb_drawing_object_id: getNewPcbDrawingObjectId(
@@ -1429,8 +1439,18 @@ export const convertElementToPrimitives = (
         const baseOffset = font_size * 1.5
         const perpX = -unitY
         const perpY = unitX
-        const textOffset =
-          Math.abs(unitX) > Math.abs(unitY) ? baseOffset : -baseOffset
+        const midpointX = (from.x + to.x) / 2
+        const midpointY = (from.y + to.y) / 2
+
+        // Determine offset direction based on which side of board the dimension is on
+        let textOffset = baseOffset
+        if (Math.abs(unitX) > Math.abs(unitY)) {
+          // Horizontal dimension: offset based on y position
+          textOffset = midpointY >= 0 ? baseOffset : -baseOffset
+        } else {
+          // Vertical dimension: offset based on x position
+          textOffset = midpointX >= 0 ? -baseOffset : baseOffset
+        }
 
         primitives.push({
           _pcb_drawing_object_id:


### PR DESCRIPTION
- Add perpendicular offset calculation for dimension text
- Text now appears above/below horizontal dimensions and left/right of vertical dimensions
- Fixes issue where text was overlapping dimension line and arrows
- Applied to both pcb_note_dimension and pcb_fabrication_note_dimension
Fixes #467
Before:
<img width="2272" height="1222" alt="511042130-32c448d1-ec3c-43d2-a51d-ccc67e8131da" src="https://github.com/user-attachments/assets/44441d7e-cf04-4829-ae75-a4b261786be8" />


After:
<img width="784" height="592" alt="image" src="https://github.com/user-attachments/assets/5ce603e1-7528-4895-9424-451031ef256d" />
