### PR TITLE
Add origin snapping point for dimension tool TSC-125

### DIFF
--- a/src/components/DimensionOverlay.tsx
+++ b/src/components/DimensionOverlay.tsx
@@ -97,9 +97,9 @@ export const DimensionOverlay = ({
 
   const snappingPoints = useMemo(() => {
     const points: {
-      anchor: NinePointAnchor
+      anchor: NinePointAnchor | "origin"
       point: { x: number; y: number }
-      element: object
+      element: object | null
     }[] = []
 
     elementBoundingBoxes.forEach((bounds, element) => {
@@ -130,6 +130,12 @@ export const DimensionOverlay = ({
           element,
         })
       }
+    })
+
+    points.push({
+      anchor: "origin",
+      point: { x: 0, y: 0 },
+      element: null,
     })
 
     return points


### PR DESCRIPTION
## Summary
- include the PCB origin as an always-available snapping target for the dimension tool
- ensure snapping metadata allows the synthetic origin point alongside element-derived anchors

## Testing
- bun run build

<img width="818" height="307" alt="image" src="https://github.com/user-attachments/assets/817af311-43f6-4c59-9ff4-0bdf4562bf8d" />
