### PR TITLE
Add corner radius support for PCB cutouts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@emotion/css": "^11.11.2",
         "@tscircuit/alphabet": "^0.0.3",
         "@vitejs/plugin-react": "^5.0.2",
-        "circuit-json": "^0.0.307",
+        "circuit-json": "^0.0.317",
         "circuit-to-svg": "^0.0.271",
         "color": "^4.2.3",
         "react-supergrid": "^1.0.10",
@@ -595,7 +595,7 @@
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
-    "circuit-json": ["circuit-json@0.0.307", "", {}, "sha512-KePvEvicSViG2FRQbz8ChO2zTqcc+wsAzmPh3oaGHO3satOMvsZJbIDJDNX+0d511n9S/qK4YVTghOIFGCERug=="],
+    "circuit-json": ["circuit-json@0.0.317", "", {}, "sha512-+xwkZPi9IsfusTcmfi5+wG18VbQV6NV+8OJGhxn0421DvLTFiR2V+shwcQPuzlCMPAXH9Jo3CeR4VZ/9+3CiCQ=="],
 
     "circuit-json-to-bpc": ["circuit-json-to-bpc@0.0.13", "", { "peerDependencies": { "bpc-graph": "*", "circuit-json": "*", "typescript": "^5" } }, "sha512-3wSMtPa6tJkiBQN4tsm7f0Mb7Wp90X2c8dNbULoDVE4mGGoFqP1DXqBlyvvZZl+4SjqznzQQ0EioLe2SCQTOcg=="],
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@emotion/css": "^11.11.2",
     "@tscircuit/alphabet": "^0.0.3",
     "@vitejs/plugin-react": "^5.0.2",
-    "circuit-json": "^0.0.307",
+    "circuit-json": "^0.0.317",
     "circuit-to-svg": "^0.0.271",
     "color": "^4.2.3",
     "react-supergrid": "^1.0.10",

--- a/src/lib/convert-element-to-primitive.ts
+++ b/src/lib/convert-element-to-primitive.ts
@@ -1282,6 +1282,10 @@ export const convertElementToPrimitives = (
       const cutoutElement = element as any
       switch (cutoutElement.shape) {
         case "rect": {
+          const corner_radius = cutoutElement.corner_radius
+          const ccw_rotation =
+            (cutoutElement as any).rotation ?? cutoutElement.ccw_rotation
+
           return [
             {
               _pcb_drawing_object_id:
@@ -1292,6 +1296,8 @@ export const convertElementToPrimitives = (
               w: cutoutElement.width,
               h: cutoutElement.height,
               layer: "drill",
+              roundness: corner_radius,
+              ccw_rotation,
               _element: element,
               _parent_pcb_component,
               _parent_source_component,

--- a/tests/lib/pcb-cutout-corner-radius.test.ts
+++ b/tests/lib/pcb-cutout-corner-radius.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "bun:test"
+import { convertElementToPrimitives } from "../../src/lib/convert-element-to-primitive"
+import type { AnyCircuitElement } from "circuit-json"
+
+test("pcb cutout rect includes corner radius and rotation", () => {
+  const cutout: AnyCircuitElement = {
+    type: "pcb_cutout",
+    pcb_cutout_id: "pcb_cutout_rect_0",
+    shape: "rect",
+    center: { x: 0, y: 0 },
+    width: 10,
+    height: 5,
+    corner_radius: 1.5,
+    rotation: 30,
+  }
+
+  const primitives = convertElementToPrimitives(cutout, [cutout])
+
+  expect(primitives).toHaveLength(1)
+  expect(primitives[0].roundness).toBe(1.5)
+  expect(primitives[0].ccw_rotation).toBe(30)
+})
+


### PR DESCRIPTION
## Summary
- update circuit-json dependency to pick up corner radius changes
- propagate pcb cutout corner radius and rotation into rendered primitives
- add a unit test covering rounded pcb cutout handling

## Testing
- bun test tests/lib/pcb-cutout-corner-radius.test.ts *(fails: missing dependencies such as @tscircuit/circuit-json-util because the registry returns 403)*
- bunx tsc --noEmit *(fails: missing React/tscircuit dependencies because packages cannot be installed due to registry 403 responses)*
- bun run format *(fails: biome binary unavailable because dependencies cannot be installed; registry access returns 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e571d71488330950dbb9b9022c736)