### PR TITLE
Add corner radius support for PCB cutouts

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
         "@emotion/css": "^11.11.2",
         "@tscircuit/alphabet": "^0.0.3",
         "@vitejs/plugin-react": "^5.0.2",
-        "circuit-json": "^0.0.307",
+        "circuit-json": "^0.0.317",
         "circuit-to-svg": "^0.0.271",
         "color": "^4.2.3",
         "react-supergrid": "^1.0.10",
@@ -595,7 +595,7 @@
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
-    "circuit-json": ["circuit-json@0.0.307", "", {}, "sha512-KePvEvicSViG2FRQbz8ChO2zTqcc+wsAzmPh3oaGHO3satOMvsZJbIDJDNX+0d511n9S/qK4YVTghOIFGCERug=="],
+    "circuit-json": ["circuit-json@0.0.317", "", {}, "sha512-+xwkZPi9IsfusTcmfi5+wG18VbQV6NV+8OJGhxn0421DvLTFiR2V+shwcQPuzlCMPAXH9Jo3CeR4VZ/9+3CiCQ=="],
 
     "circuit-json-to-bpc": ["circuit-json-to-bpc@0.0.13", "", { "peerDependencies": { "bpc-graph": "*", "circuit-json": "*", "typescript": "^5" } }, "sha512-3wSMtPa6tJkiBQN4tsm7f0Mb7Wp90X2c8dNbULoDVE4mGGoFqP1DXqBlyvvZZl+4SjqznzQQ0EioLe2SCQTOcg=="],
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@emotion/css": "^11.11.2",
     "@tscircuit/alphabet": "^0.0.3",
     "@vitejs/plugin-react": "^5.0.2",
-    "circuit-json": "^0.0.307",
+    "circuit-json": "^0.0.317",
     "circuit-to-svg": "^0.0.271",
     "color": "^4.2.3",
     "react-supergrid": "^1.0.10",

--- a/src/examples/simple/pcb-cutout-corner-radius.fixture.tsx
+++ b/src/examples/simple/pcb-cutout-corner-radius.fixture.tsx
@@ -1,0 +1,53 @@
+import type React from "react"
+import { PCBViewer } from "../../PCBViewer"
+import type { AnyCircuitElement } from "circuit-json"
+
+export const PcbCutoutCornerRadiusExample: React.FC = () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "pcb_board",
+      pcb_board_id: "pcb_board_0",
+      center: { x: 0, y: 0 },
+      width: 60,
+      height: 50,
+      material: "fr1",
+      num_layers: 2,
+      thickness: 1.2,
+    },
+    {
+      type: "pcb_cutout",
+      pcb_cutout_id: "pcb_cutout_rect_rounded_0",
+      shape: "rect",
+      center: { x: -12, y: 10 },
+      width: 10,
+      height: 6,
+      corner_radius: 2.5,
+    },
+    {
+      type: "pcb_cutout",
+      pcb_cutout_id: "pcb_cutout_rect_sharp_0",
+      shape: "rect",
+      center: { x: 12, y: 10 },
+      width: 10,
+      height: 6,
+    },
+    {
+      type: "pcb_cutout",
+      pcb_cutout_id: "pcb_cutout_rect_rounded_rotated",
+      shape: "rect",
+      center: { x: 0, y: -10 },
+      width: 12,
+      height: 5,
+      corner_radius: 1.5,
+      rotation: 45,
+    },
+  ]
+
+  return (
+    <div style={{ backgroundColor: "black", width: "100%", height: "400px" }}>
+      <PCBViewer circuitJson={circuitJson} />
+    </div>
+  )
+}
+
+export default PcbCutoutCornerRadiusExample

--- a/src/lib/convert-element-to-primitive.ts
+++ b/src/lib/convert-element-to-primitive.ts
@@ -9,6 +9,9 @@ import type {
   PcbPanel,
   PcbHole,
   PcbHoleRotatedPill,
+  PcbCutoutRect,
+  PcbCutoutCircle,
+  PcbCutoutPolygon,
 } from "circuit-json"
 import { su } from "@tscircuit/circuit-json-util"
 import type { Primitive } from "./types"
@@ -1279,9 +1282,12 @@ export const convertElementToPrimitives = (
       ]
     }
     case "pcb_cutout": {
-      const cutoutElement = element as any
-      switch (cutoutElement.shape) {
+      switch (element.shape) {
         case "rect": {
+          const cutoutElement = element as PcbCutoutRect
+          const corner_radius = cutoutElement.corner_radius
+          const ccw_rotation = cutoutElement.rotation ?? cutoutElement.rotation
+
           return [
             {
               _pcb_drawing_object_id:
@@ -1292,6 +1298,8 @@ export const convertElementToPrimitives = (
               w: cutoutElement.width,
               h: cutoutElement.height,
               layer: "drill",
+              roundness: corner_radius,
+              ccw_rotation,
               _element: element,
               _parent_pcb_component,
               _parent_source_component,
@@ -1299,6 +1307,8 @@ export const convertElementToPrimitives = (
           ]
         }
         case "circle": {
+          const cutoutElement = element as PcbCutoutCircle
+
           return [
             {
               _pcb_drawing_object_id:
@@ -1315,12 +1325,14 @@ export const convertElementToPrimitives = (
           ]
         }
         case "polygon": {
+          const cutoutElement = element as PcbCutoutPolygon
+
           return [
             {
               _pcb_drawing_object_id:
                 getNewPcbDrawingObjectId("pcb_cutout_polygon"),
               pcb_drawing_type: "polygon",
-              points: normalizePolygonPoints(cutoutElement.points as any),
+              points: normalizePolygonPoints(cutoutElement.points),
               layer: "drill",
               _element: element,
               _parent_pcb_component,
@@ -1329,7 +1341,7 @@ export const convertElementToPrimitives = (
           ]
         }
         default:
-          console.warn(`Unsupported pcb_cutout shape: ${cutoutElement.shape}`)
+          console.warn(`Unsupported pcb_cutout shape: ${element.shape}`)
           return []
       }
     }

--- a/tests/lib/pcb-cutout-corner-radius.test.ts
+++ b/tests/lib/pcb-cutout-corner-radius.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "bun:test"
+import { convertElementToPrimitives } from "../../src/lib/convert-element-to-primitive"
+import type { AnyCircuitElement } from "circuit-json"
+
+test("pcb cutout rect includes corner radius and rotation", () => {
+  const cutout: AnyCircuitElement = {
+    type: "pcb_cutout",
+    pcb_cutout_id: "pcb_cutout_rect_0",
+    shape: "rect",
+    center: { x: 0, y: 0 },
+    width: 10,
+    height: 5,
+    corner_radius: 1.5,
+    rotation: 30,
+  }
+
+  const primitives = convertElementToPrimitives(cutout, [cutout])
+
+  expect(primitives).toHaveLength(1)
+  const [primitive] = primitives
+
+  if (primitive.pcb_drawing_type !== "rect") {
+    throw new Error("Expected pcb_cutout to produce rect primitive")
+  }
+
+  const rect = primitive
+
+  expect(rect.roundness).toBe(1.5)
+  expect(rect.ccw_rotation).toBe(30)
+})


### PR DESCRIPTION
- update circuit-json dependency to pick up corner radius changes
- propagate pcb cutout corner radius and rotation into rendered primitives
- add a unit test covering rounded pcb cutout handling
