### PR TITLE
fix: add scrolling to error list in toolbar overlay

### DIFF
--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -465,6 +465,8 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
               zIndex: 1000,
               minWidth: isSmallScreen ? "280px" : "400px",
               maxWidth: isSmallScreen ? "90vw" : "600px",
+              maxHeight: "400px",
+              overflow: "auto",
               boxShadow: "0 4px 12px rgba(0, 0, 0, 0.3)",
             }}
           >


### PR DESCRIPTION
## PR Description

Fixes https://github.com/tscircuit/runframe/issues/1915
- Added `maxHeight: 400px` to limit the error list container height
- Added `overflow: auto` to enable scrolling when errors exceed the max height

### Demo


https://github.com/user-attachments/assets/ce7b79b2-8d7e-4fc2-8116-b76539b0bcc4

