### PR TITLE
Align text rendering with alphabet baseline

### DIFF
--- a/src/lib/convert-text-to-lines.ts
+++ b/src/lib/convert-text-to-lines.ts
@@ -5,6 +5,22 @@ import type { Line, Text } from "./types"
 export const LETTER_HEIGHT_TO_WIDTH_RATIO = 0.6
 export const LETTER_HEIGHT_TO_SPACE_RATIO = 0.2
 
+const LOWERCASE_BASELINE_OFFSET = (() => {
+  const referenceLetters = ["a", "c", "e", "m", "n", "o", "r", "s", "u", "x"]
+
+  const offsets = referenceLetters
+    .map((letter) => lineAlphabet[letter])
+    .filter((lines) => lines && lines.length > 0)
+    .map((lines) =>
+      Math.min(...lines.map((line) => Math.min(line.y1, line.y2))),
+    )
+
+  return offsets.length > 0 ? Math.min(...offsets) : 0
+})()
+
+const getBaselineOffsetForLetter = (letter: string) =>
+  letter >= "a" && letter <= "z" ? LOWERCASE_BASELINE_OFFSET : 0
+
 const getTextGeometry = (text: Text) => {
   const target_height = text.size * 0.7 // Apply 70% scaling
 
@@ -27,9 +43,16 @@ const getTextGeometry = (text: Text) => {
     : []
 
   const width = line_widths.length > 0 ? Math.max(...line_widths) : 0
+  const hasLowercase = /[a-z]/.test(text.text)
+  const baselineOffset = hasLowercase
+    ? LOWERCASE_BASELINE_OFFSET * target_height
+    : 0
+
   const height =
     line_count > 0
-      ? line_count * target_height + (line_count - 1) * space_between_lines
+      ? line_count * target_height +
+        (line_count - 1) * space_between_lines +
+        baselineOffset
       : 0
 
   return {
@@ -86,6 +109,7 @@ export const convertTextToLines = (text: Text): Line[] => {
       const letter = text_lines[lineIndex][letterIndex]
       const letterLines =
         lineAlphabet[letter] ?? lineAlphabet[letter.toUpperCase()]
+      const baselineOffset = getBaselineOffsetForLetter(letter)
 
       if (!letterLines) {
         current_x_origin_for_char_box += target_width_char + space_between_chars
@@ -98,13 +122,15 @@ export const convertTextToLines = (text: Text): Line[] => {
         x2: norm_x2,
         y2: norm_y2,
       } of letterLines) {
+        const adjusted_y1 = norm_y1 - baselineOffset
+        const adjusted_y2 = norm_y2 - baselineOffset
         lines.push({
           _pcb_drawing_object_id: getNewPcbDrawingObjectId("line"),
           pcb_drawing_type: "line",
           x1: current_x_origin_for_char_box + target_width_char * norm_x1,
-          y1: text.y + lineYOffset + target_height * norm_y1,
+          y1: text.y + lineYOffset + target_height * adjusted_y1,
           x2: current_x_origin_for_char_box + target_width_char * norm_x2,
-          y2: text.y + lineYOffset + target_height * norm_y2,
+          y2: text.y + lineYOffset + target_height * adjusted_y2,
           width: strokeWidth,
           layer: text.layer,
           unit: text.unit,

--- a/tests/lib/convert-text-to-lines.test.ts
+++ b/tests/lib/convert-text-to-lines.test.ts
@@ -6,6 +6,20 @@ import {
   getTextMetrics,
 } from "../../src/lib/convert-text-to-lines"
 import type { Text } from "../../src/lib/types"
+import { lineAlphabet } from "../../src/assets/alphabet"
+
+const getLowercaseBaselineOffset = () => {
+  const referenceLetters = ["a", "c", "e", "m", "n", "o", "r", "s", "u", "x"]
+
+  const offsets = referenceLetters
+    .map((letter) => lineAlphabet[letter])
+    .filter((lines) => lines && lines.length > 0)
+    .map((lines) =>
+      Math.min(...lines.map((line) => Math.min(line.y1, line.y2))),
+    )
+
+  return offsets.length > 0 ? Math.min(...offsets) : 0
+}
 
 describe("convertTextToLines", () => {
   it("supports multi-line text while preserving baseline alignment", () => {
@@ -45,5 +59,30 @@ describe("convertTextToLines", () => {
     )
     const minSecondLineY = Math.min(...secondLineYs)
     expect(minSecondLineY).toBeCloseTo(expectedTargetHeight + expectedSpacing)
+  })
+
+  it("keeps lowercase letters on the baseline and renders descenders below it", () => {
+    const text: Text = {
+      _pcb_drawing_object_id: "text_1",
+      pcb_drawing_type: "text",
+      text: "ap",
+      x: 0,
+      y: 5,
+      size: 10,
+      layer: "top_silkscreen",
+    }
+
+    const baselineOffset = getLowercaseBaselineOffset()
+    const targetHeight = text.size * 0.7
+
+    const aOnlyLines = convertTextToLines({ ...text, text: "a" })
+    const aYs = aOnlyLines.flatMap((line) => [line.y1, line.y2])
+    expect(Math.min(...aYs)).toBeCloseTo(text.y)
+
+    const lines = convertTextToLines(text)
+    const yValues = lines.flatMap((line) => [line.y1, line.y2])
+    const minY = Math.min(...yValues)
+
+    expect(minY).toBeCloseTo(text.y - baselineOffset * targetHeight)
   })
 })


### PR DESCRIPTION
## Summary
- offset lowercase alphabet glyphs using the library baseline instead of centered positioning
- include baseline offset in text metrics to account for descender depth
- add tests confirming baseline placement and descender rendering for lowercase text

## Testing
- bun test tests/lib/convert-text-to-lines.test.ts
- bunx tsc --noEmit

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692f793b9020832eab27aa86d59a1b19)