### PR TITLE
Render component outline and anchor on hover

### DIFF
--- a/src/components/GroupAnchorOffsetOverlay/constants.ts
+++ b/src/components/GroupAnchorOffsetOverlay/constants.ts
@@ -9,6 +9,8 @@ export const VISUAL_CONFIG = {
   LINE_DASH_PATTERN: "4,4",
   COMPONENT_MARKER_RADIUS: 3,
   LABEL_FONT_SIZE: 11,
+  COMPONENT_ANCHOR_MARKER_SIZE: 6,
+  GROUP_ANCHOR_MARKER_SIZE: 7,
 } as const
 
 export const COLORS = {
@@ -16,4 +18,6 @@ export const COLORS = {
   COMPONENT_MARKER_FILL: "#66ccff",
   COMPONENT_MARKER_STROKE: "white",
   LABEL_TEXT: "white",
+  COMPONENT_OUTLINE: "white",
+  ANCHOR_MARKER: "white",
 } as const


### PR DESCRIPTION
## Summary
- outline hovered components with a white polygon and draw component anchor markers
- show group anchor markers and offset guides from group anchors to component anchors when applicable
- support rotated components by deriving polygon corners before applying screen transforms

## Testing
- bunx tsc --noEmit
- bun run format


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_693a2bbedc9c832eb0e29bdc540c4044)