### PR TITLE
Fix group center markers to show cross/plus sign instead of circle

### DIFF
--- a/src/components/AnchorOffsetOverlay/Board/index.tsx
+++ b/src/components/AnchorOffsetOverlay/Board/index.tsx
@@ -240,14 +240,35 @@ export const BoardAnchorOffsetOverlay = ({
                 strokeDasharray={VISUAL_CONFIG.LINE_DASH_PATTERN}
               />
 
-              <circle
-                cx={targetScreen.x}
-                cy={targetScreen.y}
-                r={VISUAL_CONFIG.COMPONENT_MARKER_RADIUS}
-                fill={COLORS.COMPONENT_MARKER_FILL}
-                stroke={COLORS.COMPONENT_MARKER_STROKE}
-                strokeWidth={1}
-              />
+              {target.type === "component" ? (
+                <circle
+                  cx={targetScreen.x}
+                  cy={targetScreen.y}
+                  r={VISUAL_CONFIG.COMPONENT_MARKER_RADIUS}
+                  fill={COLORS.COMPONENT_MARKER_FILL}
+                  stroke={COLORS.COMPONENT_MARKER_STROKE}
+                  strokeWidth={1}
+                />
+              ) : (
+                <>
+                  <line
+                    x1={targetScreen.x - VISUAL_CONFIG.ANCHOR_MARKER_SIZE}
+                    y1={targetScreen.y}
+                    x2={targetScreen.x + VISUAL_CONFIG.ANCHOR_MARKER_SIZE}
+                    y2={targetScreen.y}
+                    stroke={COLORS.OFFSET_LINE}
+                    strokeWidth={VISUAL_CONFIG.ANCHOR_MARKER_STROKE_WIDTH}
+                  />
+                  <line
+                    x1={targetScreen.x}
+                    y1={targetScreen.y - VISUAL_CONFIG.ANCHOR_MARKER_SIZE}
+                    x2={targetScreen.x}
+                    y2={targetScreen.y + VISUAL_CONFIG.ANCHOR_MARKER_SIZE}
+                    stroke={COLORS.OFFSET_LINE}
+                    strokeWidth={VISUAL_CONFIG.ANCHOR_MARKER_STROKE_WIDTH}
+                  />
+                </>
+              )}
 
               {shouldShowXLabel && (
                 <foreignObject

--- a/src/components/AnchorOffsetOverlay/Group/index.tsx
+++ b/src/components/AnchorOffsetOverlay/Group/index.tsx
@@ -290,14 +290,35 @@ export const GroupAnchorOffsetOverlay = ({
                 strokeDasharray={VISUAL_CONFIG.LINE_DASH_PATTERN}
               />
 
-              <circle
-                cx={targetScreen.x}
-                cy={targetScreen.y}
-                r={VISUAL_CONFIG.COMPONENT_MARKER_RADIUS}
-                fill={COLORS.COMPONENT_MARKER_FILL}
-                stroke={COLORS.COMPONENT_MARKER_STROKE}
-                strokeWidth={1}
-              />
+              {target.type === "component" ? (
+                <circle
+                  cx={targetScreen.x}
+                  cy={targetScreen.y}
+                  r={VISUAL_CONFIG.COMPONENT_MARKER_RADIUS}
+                  fill={COLORS.COMPONENT_MARKER_FILL}
+                  stroke={COLORS.COMPONENT_MARKER_STROKE}
+                  strokeWidth={1}
+                />
+              ) : (
+                <>
+                  <line
+                    x1={targetScreen.x - VISUAL_CONFIG.ANCHOR_MARKER_SIZE}
+                    y1={targetScreen.y}
+                    x2={targetScreen.x + VISUAL_CONFIG.ANCHOR_MARKER_SIZE}
+                    y2={targetScreen.y}
+                    stroke={COLORS.OFFSET_LINE}
+                    strokeWidth={VISUAL_CONFIG.ANCHOR_MARKER_STROKE_WIDTH}
+                  />
+                  <line
+                    x1={targetScreen.x}
+                    y1={targetScreen.y - VISUAL_CONFIG.ANCHOR_MARKER_SIZE}
+                    x2={targetScreen.x}
+                    y2={targetScreen.y + VISUAL_CONFIG.ANCHOR_MARKER_SIZE}
+                    stroke={COLORS.OFFSET_LINE}
+                    strokeWidth={VISUAL_CONFIG.ANCHOR_MARKER_STROKE_WIDTH}
+                  />
+                </>
+              )}
 
               {shouldShowXLabel && (
                 <foreignObject


### PR DESCRIPTION
https://pcb-viewer-qyzssypfp-tscircuit.vercel.app/?fixture=%7B%22path%22%3A%22src%2Fexamples%2Fgroup-to-group-and-board-anchor.fixture.tsx%22%7D

Before
<img width="781" height="381" alt="Screenshot_2025-12-13_22-45-06" src="https://github.com/user-attachments/assets/ed720048-3ca7-4126-95c0-6773a448fe7b" />

After
<img width="886" height="347" alt="Screenshot_2025-12-13_22-44-13" src="https://github.com/user-attachments/assets/fd745216-7abf-4d74-b533-c3fd0dd871eb" />
