### PR TITLE
Use displayOffsetY for Board Δy label

### DIFF
--- a/src/components/AnchorOffsetOverlay/Board/index.tsx
+++ b/src/components/AnchorOffsetOverlay/Board/index.tsx
@@ -213,8 +213,8 @@ export const BoardAnchorOffsetOverlay = ({
           const shouldShowYLabel =
             yLineLength > VISUAL_CONFIG.MIN_LINE_LENGTH_FOR_LABEL
 
-          const xLabelText = `Board Δx: ${displayOffsetX ? displayOffsetX : offsetX.toFixed(2)}mm`
-          const yLabelText = `Board Δy: ${displayOffsetY ? displayOffsetY : offsetY.toFixed(2)}mm`
+          const xLabelText = `${displayOffsetX ?? offsetX.toFixed(2)}mm`
+          const yLabelText = `${displayOffsetY ?? offsetY.toFixed(2)}mm`
 
           return (
             <g key={`${target.board.pcb_board_id}-${targetId}-${target.type}`}>


### PR DESCRIPTION
This pull request includes a small fix to the `BoardAnchorOffsetOverlay` component. The change corrects the label for the Y offset to use the correct display value, ensuring that the Y label now properly reflects the intended offset value.