### PR TITLE
Prefer calculated anchor offsets when moving

### DIFF
--- a/src/components/AnchorOffsetOverlay/Board/index.tsx
+++ b/src/components/AnchorOffsetOverlay/Board/index.tsx
@@ -63,6 +63,7 @@ export const BoardAnchorOffsetOverlay = ({
   const isShowingAnchorOffsets = useGlobalStore(
     (state) => state.is_showing_group_anchor_offsets,
   )
+  const isMovingComponent = useGlobalStore((s) => s.is_moving_component)
 
   if (!isShowingAnchorOffsets && hoveredComponentIds.length === 0) {
     return null
@@ -213,8 +214,26 @@ export const BoardAnchorOffsetOverlay = ({
           const shouldShowYLabel =
             yLineLength > VISUAL_CONFIG.MIN_LINE_LENGTH_FOR_LABEL
 
-          const xLabelText = `Board Δx: ${displayOffsetX ? displayOffsetX : offsetX.toFixed(2)}mm`
-          const yLabelText = `Board Δy: ${displayOffsetX ? displayOffsetX : offsetY.toFixed(2)}mm`
+          // Always show calculated offset when component is being moved or when stored offset doesn't match current position
+          const storedOffsetX = displayOffsetX
+            ? parseFloat(displayOffsetX)
+            : null
+          const storedOffsetY = displayOffsetY
+            ? parseFloat(displayOffsetY)
+            : null
+          const offsetMatchesStored =
+            storedOffsetX !== null &&
+            storedOffsetY !== null &&
+            Math.abs(offsetX - storedOffsetX) < 0.01 && // Allow small tolerance for floating point precision
+            Math.abs(offsetY - storedOffsetY) < 0.01
+
+          const shouldUseCalculatedOffset =
+            isMovingComponent ||
+            !displayOffsetX ||
+            !displayOffsetY ||
+            !offsetMatchesStored
+          const xLabelText = `Board Δx: ${shouldUseCalculatedOffset ? offsetX.toFixed(2) : displayOffsetX || offsetX.toFixed(2)}mm`
+          const yLabelText = `Board Δy: ${shouldUseCalculatedOffset ? offsetY.toFixed(2) : displayOffsetY || offsetY.toFixed(2)}mm`
 
           return (
             <g key={`${target.board.pcb_board_id}-${targetId}-${target.type}`}>

--- a/src/components/AnchorOffsetOverlay/Group/index.tsx
+++ b/src/components/AnchorOffsetOverlay/Group/index.tsx
@@ -92,6 +92,7 @@ export const GroupAnchorOffsetOverlay = ({
   const isShowingAnchorOffsets = useGlobalStore(
     (s) => s.is_showing_group_anchor_offsets,
   )
+  const isMovingComponent = useGlobalStore((s) => s.is_moving_component)
 
   if (!isShowingAnchorOffsets && hoveredComponentIds.length === 0) {
     return null
@@ -287,8 +288,26 @@ export const GroupAnchorOffsetOverlay = ({
           const shouldShowYLabel =
             yLineLength > VISUAL_CONFIG.MIN_LINE_LENGTH_FOR_LABEL
 
-          const xLabelText = `Δx: ${displayOffsetX ? displayOffsetX : offsetX.toFixed(2)}mm`
-          const yLabelText = `Δy: ${displayOffsetY ? displayOffsetY : offsetY.toFixed(2)}mm`
+          // Always show calculated offset when component is being moved or when stored offset doesn't match current position
+          const storedOffsetX = displayOffsetX
+            ? parseFloat(displayOffsetX)
+            : null
+          const storedOffsetY = displayOffsetY
+            ? parseFloat(displayOffsetY)
+            : null
+          const offsetMatchesStored =
+            storedOffsetX !== null &&
+            storedOffsetY !== null &&
+            Math.abs(offsetX - storedOffsetX) < 0.01 && // Allow small tolerance for floating point precision
+            Math.abs(offsetY - storedOffsetY) < 0.01
+
+          const shouldUseCalculatedOffset =
+            isMovingComponent ||
+            !displayOffsetX ||
+            !displayOffsetY ||
+            !offsetMatchesStored
+          const xLabelText = `Δx: ${shouldUseCalculatedOffset ? offsetX.toFixed(2) : displayOffsetX || offsetX.toFixed(2)}mm`
+          const yLabelText = `Δy: ${shouldUseCalculatedOffset ? offsetY.toFixed(2) : displayOffsetY || offsetY.toFixed(2)}mm`
 
           return (
             <g


### PR DESCRIPTION
This pull request updates the anchor offset overlays for both board and group components to ensure that the displayed offset labels always reflect the most accurate position, especially when a component is being moved or when the stored offset does not match the current position. The logic for determining when to show the calculated offset versus the stored offset has been improved for better accuracy and user feedback.

**Enhancements to anchor offset overlay display:**

* Both `BoardAnchorOffsetOverlay` and `GroupAnchorOffsetOverlay` now check if a component is being moved (`isMovingComponent`) and always show the calculated offset if so, or if the stored offset is missing or out of sync with the current position. [[1]](diffhunk://#diff-84e41d9d9bb85e329a1ddbea7cb4417aca5aaf2a4ece3a7159899a908bab9916R66) [[2]](diffhunk://#diff-dd7718e69c17fb5bd19e04c15f1c4de5404cc4be4297de33fdfd19002aaf4deeR95)
* Added logic to compare the stored and calculated offsets with a tolerance for floating point precision, ensuring that the label only uses the stored value when it accurately reflects the component's position. [[1]](diffhunk://#diff-84e41d9d9bb85e329a1ddbea7cb4417aca5aaf2a4ece3a7159899a908bab9916L216-R236) [[2]](diffhunk://#diff-dd7718e69c17fb5bd19e04c15f1c4de5404cc4be4297de33fdfd19002aaf4deeL290-R310)
* The label text in both overlays now conditionally displays the most relevant offset value based on the new logic, improving real-time feedback during component movement. [[1]](diffhunk://#diff-84e41d9d9bb85e329a1ddbea7cb4417aca5aaf2a4ece3a7159899a908bab9916L216-R236) [[2]](diffhunk://#diff-dd7718e69c17fb5bd19e04c15f1c4de5404cc4be4297de33fdfd19002aaf4deeL290-R310)

## Before

https://github.com/user-attachments/assets/a4a54d1a-5b6a-456d-ad09-4e5ffda2f068

## After

https://github.com/user-attachments/assets/fd6f6606-84c9-44ac-9e8b-28e13007cd31

