### PR TITLE
Fix duplicate delta x/y and mm units in nested group anchor offset display

### DIFF
--- a/src/components/AnchorOffsetOverlay/Group/index.tsx
+++ b/src/components/AnchorOffsetOverlay/Group/index.tsx
@@ -289,10 +289,10 @@ export const GroupAnchorOffsetOverlay = ({
 
           const xLabelText = displayOffsetX
             ? displayOffsetX
-            : `${offsetX.toFixed(2)}`
+            : `${offsetX.toFixed(2)}mm`
           const yLabelText = displayOffsetY
             ? displayOffsetY
-            : `${offsetY.toFixed(2)}`
+            : `${offsetY.toFixed(2)}mm`
 
           return (
             <g


### PR DESCRIPTION
Before
<img width="1041" height="401" alt="Screenshot_2025-12-20_17-36-58" src="https://github.com/user-attachments/assets/287e546a-0cf6-4c09-af1a-3bcb600d7b6b" />


After
<img width="993" height="317" alt="Screenshot_2025-12-21_09-34-14" src="https://github.com/user-attachments/assets/3ac4ac0b-55e9-44f6-b33d-02f6689366de" />

