### PR TITLE
Allow selecting error text in dropdown

### DIFF
--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -493,7 +493,6 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
                       backgroundColor: "#2a2a2a",
                       transition: "background-color 0.2s ease",
                       touchAction: "manipulation",
-                      userSelect: "none",
                     }}
                     onMouseEnter={(e) => {
                       e.currentTarget.style.backgroundColor = "#333"
@@ -562,7 +561,10 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
                         overflow: "hidden",
                         textOverflow: "ellipsis",
                         whiteSpace: "nowrap",
+                        userSelect: "text",
                       }}
+                      onMouseDown={(event) => event.stopPropagation()}
+                      onClick={(event) => event.stopPropagation()}
                     >
                       {e.message}
                     </div>
@@ -602,7 +604,10 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
                         wordWrap: "break-word",
                         overflowWrap: "break-word",
                         hyphens: "auto",
+                        userSelect: "text",
                       }}
+                      onMouseDown={(event) => event.stopPropagation()}
+                      onClick={(event) => event.stopPropagation()}
                     >
                       {e.message}
                     </div>


### PR DESCRIPTION
### Motivation
- The error list rows prevented text selection because row-level interaction settings and handlers intercepted pointer events.
- Users need to be able to select and copy error messages from the dropdown for debugging and reporting.

### Description
- Removed `userSelect: "none"` from the clickable error row container to allow text selection.
- Added `userSelect: "text"` to both the collapsed message and expanded message divs to explicitly enable selection.
- Added `onMouseDown` and `onClick` handlers that call `event.stopPropagation()` on the message elements to prevent the row click/touch handlers from hijacking selection.
- Changes applied in `src/components/ToolbarOverlay.tsx`.

### Testing
- Ran `bunx tsc --noEmit` to typecheck the project and it completed successfully.
- Ran `bun run format` to apply formatting and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69561ec3c87c832e991656f906fd67c8)