### PR TITLE
Add native PCB cutout rendering on Edge.Cuts via circuit-to-canvas

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@tscircuit/math-utils": "^0.0.29",
         "@vitejs/plugin-react": "^5.0.2",
         "circuit-json": "^0.0.353",
-        "circuit-to-canvas": "^0.0.37",
+        "circuit-to-canvas": "^0.0.41",
         "circuit-to-svg": "^0.0.271",
         "color": "^4.2.3",
         "react-supergrid": "^1.0.10",
@@ -637,7 +637,7 @@
 
     "circuit-json-to-spice": ["circuit-json-to-spice@0.0.30", "", { "dependencies": { "circuit-json-to-connectivity-map": "^0.0.22" }, "peerDependencies": { "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "typescript": "^5.0.0" } }, "sha512-ArMfJhxh7lWI1OiZLMNBong7r3tArX9Q6JOprDPirku0bUZwLXr5AY4w/pDlkEivlaRX6yvamqebWja6yIONog=="],
 
-    "circuit-to-canvas": ["circuit-to-canvas@0.0.37", "", { "dependencies": { "transformation-matrix": "^3.1.0" }, "peerDependencies": { "@tscircuit/alphabet": "*", "typescript": "^5" } }, "sha512-qs7eHVav1aHhMNjPa/Qnmq3iz8ILW3wkrsuiULO4QYwb8CeC9CIoUSbGA6AaO36M8PUQVnbjVjrpnY77X95zGw=="],
+    "circuit-to-canvas": ["circuit-to-canvas@0.0.41", "", { "dependencies": { "transformation-matrix": "^3.1.0" }, "peerDependencies": { "@tscircuit/alphabet": "*", "typescript": "^5" } }, "sha512-A+lHqqlbBMQniR732mW2WJPtrZ5tNooK+dENZmSRUGkNtE8WZUBfLX/Wui2NgzBZAMTouG+Hf5FkV8ZiJAtWLw=="],
 
     "circuit-to-svg": ["circuit-to-svg@0.0.271", "", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "calculate-elbow": "0.0.12", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" } }, "sha512-6g57xJT5lGiiSr29NIZztSwWhXq50ZXgwYbU2NCDLooZNXIz3d+sDrwhHltax53czFrt6w8q1om2XGPZHzAq6g=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@tscircuit/math-utils": "^0.0.29",
     "@vitejs/plugin-react": "^5.0.2",
     "circuit-json": "^0.0.353",
-    "circuit-to-canvas": "^0.0.37",
+    "circuit-to-canvas": "^0.0.41",
     "circuit-to-svg": "^0.0.271",
     "color": "^4.2.3",
     "react-supergrid": "^1.0.10",

--- a/src/components/CanvasPrimitiveRenderer.tsx
+++ b/src/components/CanvasPrimitiveRenderer.tsx
@@ -13,6 +13,7 @@ import { drawFabricationNoteElementsForLayer } from "lib/draw-fabrication-note"
 import { drawPcbNoteElementsForLayer } from "lib/draw-pcb-note"
 import { drawPcbHoleElementsForLayer } from "lib/draw-hole"
 import { drawPcbBoardElements } from "lib/draw-pcb-board"
+import { drawPcbCutoutElementsForLayer } from "lib/draw-pcb-cutout"
 
 interface Props {
   primitives: Primitive[]
@@ -43,6 +44,7 @@ const orderedLayers = [
   "inner5",
   "inner6",
   "drill",
+  "edge_cuts",
   "bottom_notes",
   "top_notes",
   "other",
@@ -176,6 +178,17 @@ export const CanvasPrimitiveRenderer = ({
       const boardCanvas = canvasRefs.current.board
       if (boardCanvas) {
         drawPcbBoardElements(boardCanvas, elements, [], transform)
+      }
+
+      // Draw PCB cutouts using circuit-to-canvas
+      const edgeCutsCanvas = canvasRefs.current.edge_cuts
+      if (edgeCutsCanvas) {
+        drawPcbCutoutElementsForLayer(
+          edgeCutsCanvas,
+          elements,
+          ["edge_cuts"],
+          transform,
+        )
       }
     }
 

--- a/src/lib/convert-element-to-primitive.ts
+++ b/src/lib/convert-element-to-primitive.ts
@@ -7,9 +7,6 @@ import type {
   PcbNoteDimension,
   PcbSmtPadRotatedPill,
   PcbPanel,
-  PcbCutoutRect,
-  PcbCutoutCircle,
-  PcbCutoutPolygon,
 } from "circuit-json"
 import { su } from "@tscircuit/circuit-json-util"
 import type { Primitive } from "./types"
@@ -377,70 +374,6 @@ export const convertElementToPrimitives = (
         }
       }
       return []
-    }
-    case "pcb_cutout": {
-      switch (element.shape) {
-        case "rect": {
-          const cutoutElement = element as PcbCutoutRect
-          const corner_radius = cutoutElement.corner_radius
-          const ccw_rotation = cutoutElement.rotation ?? cutoutElement.rotation
-
-          return [
-            {
-              _pcb_drawing_object_id:
-                getNewPcbDrawingObjectId("pcb_cutout_rect"),
-              pcb_drawing_type: "rect",
-              x: cutoutElement.center.x,
-              y: cutoutElement.center.y,
-              w: cutoutElement.width,
-              h: cutoutElement.height,
-              layer: "drill",
-              roundness: corner_radius,
-              ccw_rotation,
-              _element: element,
-              _parent_pcb_component,
-              _parent_source_component,
-            },
-          ]
-        }
-        case "circle": {
-          const cutoutElement = element as PcbCutoutCircle
-
-          return [
-            {
-              _pcb_drawing_object_id:
-                getNewPcbDrawingObjectId("pcb_cutout_circle"),
-              pcb_drawing_type: "circle",
-              x: cutoutElement.center.x,
-              y: cutoutElement.center.y,
-              r: cutoutElement.radius,
-              layer: "drill",
-              _element: element,
-              _parent_pcb_component,
-              _parent_source_component,
-            },
-          ]
-        }
-        case "polygon": {
-          const cutoutElement = element as PcbCutoutPolygon
-
-          return [
-            {
-              _pcb_drawing_object_id:
-                getNewPcbDrawingObjectId("pcb_cutout_polygon"),
-              pcb_drawing_type: "polygon",
-              points: normalizePolygonPoints(cutoutElement.points),
-              layer: "drill",
-              _element: element,
-              _parent_pcb_component,
-              _parent_source_component,
-            },
-          ]
-        }
-        default:
-          console.warn(`Unsupported pcb_cutout shape: ${element.shape}`)
-          return []
-      }
     }
   }
 

--- a/src/lib/draw-pcb-cutout.ts
+++ b/src/lib/draw-pcb-cutout.ts
@@ -1,0 +1,22 @@
+import { CircuitToCanvasDrawer } from "circuit-to-canvas"
+import type { AnyCircuitElement, PcbRenderLayer } from "circuit-json"
+import type { Matrix } from "transformation-matrix"
+
+export function isPcbCutout(element: AnyCircuitElement) {
+  return element.type === "pcb_cutout"
+}
+
+export function drawPcbCutoutElementsForLayer(
+  canvas: HTMLCanvasElement,
+  elements: AnyCircuitElement[],
+  layers: PcbRenderLayer[],
+  realToCanvasMat: Matrix,
+) {
+  const drawer = new CircuitToCanvasDrawer(canvas)
+
+  drawer.realToCanvasMat = realToCanvasMat
+
+  const cutoutElements = elements.filter(isPcbCutout)
+
+  drawer.drawElements(cutoutElements, { layers })
+}


### PR DESCRIPTION
This change introduces first-class PCB cutout support in the canvas viewer by delegating rendering to `circuit-to-canvas`.
It adds a dedicated `edge_cuts` layer, integrates cutout drawing into the render pipeline, and removes legacy primitive conversion logic.
The update aligns the viewer with upstream PCB semantics, improves correctness for board outlines and mechanical features, and unblocks accurate visualization of complex designs.
Includes a dependency upgrade to leverage the new cutout rendering capabilities.