### PR TITLE
Add hovered SMT pad rendering with highlight support via circuit-to-canvas

### DIFF
--- a/src/components/CanvasPrimitiveRenderer.tsx
+++ b/src/components/CanvasPrimitiveRenderer.tsx
@@ -109,23 +109,23 @@ export const CanvasPrimitiveRenderer = ({
 
       // Draw SMT pads using circuit-to-canvas (on copper layers)
       if (topCanvas) {
-        drawPcbSmtPadElementsForLayer(
-          topCanvas,
+        drawPcbSmtPadElementsForLayer({
+          canvas: topCanvas,
           elements,
-          ["top_copper"],
-          transform,
+          layers: ["top_copper"],
+          realToCanvasMat: transform,
           primitives,
-        )
+        })
       }
 
       if (bottomCanvas) {
-        drawPcbSmtPadElementsForLayer(
-          bottomCanvas,
+        drawPcbSmtPadElementsForLayer({
+          canvas: bottomCanvas,
           elements,
-          ["bottom_copper"],
-          transform,
+          layers: ["bottom_copper"],
+          realToCanvasMat: transform,
           primitives,
-        )
+        })
       }
 
       // Draw top silkscreen

--- a/src/lib/draw-pcb-smtpad.ts
+++ b/src/lib/draw-pcb-smtpad.ts
@@ -22,13 +22,19 @@ export function isPcbSmtPad(element: AnyCircuitElement) {
   return element.type === "pcb_smtpad"
 }
 
-export function drawPcbSmtPadElementsForLayer(
-  canvas: HTMLCanvasElement,
-  elements: AnyCircuitElement[],
-  layers: PcbRenderLayer[],
-  realToCanvasMat: Matrix,
-  primitives?: any[],
-) {
+export function drawPcbSmtPadElementsForLayer({
+  canvas,
+  elements,
+  layers,
+  realToCanvasMat,
+  primitives,
+}: {
+  canvas: HTMLCanvasElement
+  elements: AnyCircuitElement[]
+  layers: PcbRenderLayer[]
+  realToCanvasMat: Matrix
+  primitives?: any[]
+}) {
   // Filter SMT pads to only those on the specified layers
   const smtPadElements = elements.filter(isPcbSmtPad).filter((element) => {
     const elementLayer = element.layer


### PR DESCRIPTION
Switches SMT pad rendering to circuit-to-canvas for correct copper-layer drawing.

Adds hover-aware color adjustment to visually highlight SMT pads under interaction.

Preserves the existing primitive overlay for debugging and inspection.

Ensures SMT pads are excluded from the generic primitive pass to avoid duplicate or inconsistent rendering.


tests:
https://pcb-viewer-git-fork-abse2001-main-tscircuit.vercel.app/?fixture=%7B%22path%22%3A%22src%2Fexamples%2F2025%2Fpill-smtpad.fixture.tsx%22%7D

https://pcb-viewer-git-fork-abse2001-main-tscircuit.vercel.app/?fixture=%7B%22path%22%3A%22src%2Fexamples%2F2025%2Fpolygon-smtpad.fixture.tsx%22%7D


https://pcb-viewer-git-fork-abse2001-main-tscircuit.vercel.app/?fixture=%7B%22path%22%3A%22src%2Fexamples%2F2025%2Ftracehint.fixture.tsx%22%7D

https://pcb-viewer-git-fork-abse2001-main-tscircuit.vercel.app/?fixture=%7B%22path%22%3A%22src%2Fexamples%2F2025%2Fdisable-pcb-groups.fixture.tsx%22%2C%22name%22%3A%22DisablePcbGroupsWithLocalStorage%22%7D
