### PR TITLE
Migrate Copper Pour Rendering to circuit-to-canvas with Layer-Accurate Drawing

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@tscircuit/math-utils": "^0.0.29",
         "@vitejs/plugin-react": "^5.0.2",
         "circuit-json": "^0.0.354",
-        "circuit-to-canvas": "^0.0.47",
+        "circuit-to-canvas": "^0.0.48",
         "circuit-to-svg": "^0.0.271",
         "color": "^4.2.3",
         "react-supergrid": "^1.0.10",
@@ -637,7 +637,7 @@
 
     "circuit-json-to-spice": ["circuit-json-to-spice@0.0.30", "", { "dependencies": { "circuit-json-to-connectivity-map": "^0.0.22" }, "peerDependencies": { "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "typescript": "^5.0.0" } }, "sha512-ArMfJhxh7lWI1OiZLMNBong7r3tArX9Q6JOprDPirku0bUZwLXr5AY4w/pDlkEivlaRX6yvamqebWja6yIONog=="],
 
-    "circuit-to-canvas": ["circuit-to-canvas@0.0.47", "", { "dependencies": { "transformation-matrix": "^3.1.0" }, "peerDependencies": { "@tscircuit/alphabet": "*", "typescript": "^5" } }, "sha512-DcGy7TZTEOGSoFL94pYhMs8lzrVen8KKPTtpXvqJYwXz/9i5evHylqmdtl4MmSntgf8utN1Px9Y2m1rSDbXpew=="],
+    "circuit-to-canvas": ["circuit-to-canvas@0.0.48", "", { "dependencies": { "transformation-matrix": "^3.1.0" }, "peerDependencies": { "@tscircuit/alphabet": "*", "typescript": "^5" } }, "sha512-+2pb8/1vdjRJwhSblvnLHG1G1uZ5JEobe0XJfXMIxvAFT0mJ7wfLlxxfZivWJoCPIoAQaEYPe5MiWS30bvrRKA=="],
 
     "circuit-to-svg": ["circuit-to-svg@0.0.271", "", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "calculate-elbow": "0.0.12", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" } }, "sha512-6g57xJT5lGiiSr29NIZztSwWhXq50ZXgwYbU2NCDLooZNXIz3d+sDrwhHltax53czFrt6w8q1om2XGPZHzAq6g=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@tscircuit/math-utils": "^0.0.29",
     "@vitejs/plugin-react": "^5.0.2",
     "circuit-json": "^0.0.354",
-    "circuit-to-canvas": "^0.0.47",
+    "circuit-to-canvas": "^0.0.48",
     "circuit-to-svg": "^0.0.271",
     "color": "^4.2.3",
     "react-supergrid": "^1.0.10",

--- a/src/components/CanvasPrimitiveRenderer.tsx
+++ b/src/components/CanvasPrimitiveRenderer.tsx
@@ -17,6 +17,7 @@ import { drawPcbCutoutElementsForLayer } from "lib/draw-pcb-cutout"
 import { drawPcbSmtPadElementsForLayer } from "lib/draw-pcb-smtpad"
 import { drawPcbKeepoutElementsForLayer } from "lib/draw-pcb-keepout"
 import { drawPcbViaElementsForLayer } from "lib/draw-via"
+import { drawCopperPourElementsForLayer } from "lib/draw-copper-pour"
 
 interface Props {
   primitives: Primitive[]
@@ -162,6 +163,25 @@ export const CanvasPrimitiveRenderer = ({
           layers: ["bottom_copper"],
           realToCanvasMat: transform,
           primitives,
+        })
+      }
+
+      // Draw copper pour elements using circuit-to-canvas (on copper layers)
+      if (topCanvas) {
+        drawCopperPourElementsForLayer({
+          canvas: topCanvas,
+          elements,
+          layers: ["top_copper"],
+          realToCanvasMat: transform,
+        })
+      }
+
+      if (bottomCanvas) {
+        drawCopperPourElementsForLayer({
+          canvas: bottomCanvas,
+          elements,
+          layers: ["bottom_copper"],
+          realToCanvasMat: transform,
         })
       }
 

--- a/src/lib/convert-element-to-primitive.ts
+++ b/src/lib/convert-element-to-primitive.ts
@@ -627,59 +627,6 @@ export const convertElementToPrimitives = (
         _parent_source_component,
       })
     }
-    case "pcb_copper_pour": {
-      const pour = element
-
-      switch (pour.shape) {
-        case "rect": {
-          const { center, width, height, layer, rotation } = pour
-          return [
-            {
-              _pcb_drawing_object_id: getNewPcbDrawingObjectId(
-                "pcb_copper_pour_rect",
-              ),
-              pcb_drawing_type: "rect",
-              x: center.x,
-              y: center.y,
-              w: width,
-              h: height,
-              layer: layer,
-              _element: element,
-              ccw_rotation: rotation,
-            },
-          ]
-        }
-        case "polygon": {
-          const { points, layer } = pour
-          return [
-            {
-              _pcb_drawing_object_id: getNewPcbDrawingObjectId(
-                "pcb_copper_pour_polygon",
-              ),
-              pcb_drawing_type: "polygon",
-              points: normalizePolygonPoints(points),
-              layer: layer,
-              _element: element,
-            },
-          ]
-        }
-        case "brep": {
-          const { brep_shape, layer } = pour
-          return [
-            {
-              _pcb_drawing_object_id: getNewPcbDrawingObjectId(
-                "pcb_copper_pour_brep",
-              ),
-              pcb_drawing_type: "polygon_with_arcs",
-              brep_shape: brep_shape,
-              layer: layer,
-              _element: element,
-            },
-          ]
-        }
-      }
-      return []
-    }
   }
 
   return []

--- a/src/lib/draw-copper-pour.ts
+++ b/src/lib/draw-copper-pour.ts
@@ -1,0 +1,28 @@
+import type { AnyCircuitElement, PcbRenderLayer } from "circuit-json"
+import { CircuitToCanvasDrawer } from "circuit-to-canvas"
+import type { Matrix } from "transformation-matrix"
+
+export function isCopperPourElement(element: AnyCircuitElement) {
+  return element.type === "pcb_copper_pour"
+}
+
+export function drawCopperPourElementsForLayer({
+  canvas,
+  elements,
+  layers,
+  realToCanvasMat,
+}: {
+  canvas: HTMLCanvasElement
+  elements: AnyCircuitElement[]
+  layers: PcbRenderLayer[]
+  realToCanvasMat: Matrix
+}) {
+  const copperPourElements = elements.filter(isCopperPourElement)
+
+  if (copperPourElements.length === 0) return
+
+  // Draw all copper pour elements with default colors
+  const drawer = new CircuitToCanvasDrawer(canvas)
+  drawer.realToCanvasMat = realToCanvasMat
+  drawer.drawElements(copperPourElements, { layers })
+}


### PR DESCRIPTION
Moves pcb_copper_pour rendering out of primitive conversion and into circuit-to-canvas

Introduces a dedicated copper pour renderer with correct top/bottom copper layer handling

Simplifies the rendering pipeline and aligns copper pours with the unified canvas-based flow

Updates circuit-to-canvas to v0.0.48 to support the new rendering path