### PR TITLE
Fix soldermask and drill layer ordering with explicit soldermask rendering and hover support

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@tscircuit/math-utils": "^0.0.29",
         "@vitejs/plugin-react": "^5.0.2",
         "circuit-json": "^0.0.356",
-        "circuit-to-canvas": "^0.0.60",
+        "circuit-to-canvas": "^0.0.61",
         "circuit-to-svg": "^0.0.271",
         "color": "^4.2.3",
         "react-supergrid": "^1.0.10",
@@ -635,7 +635,7 @@
 
     "circuit-json-to-spice": ["circuit-json-to-spice@0.0.33", "", { "dependencies": { "circuit-json-to-connectivity-map": "^0.0.22" }, "peerDependencies": { "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "typescript": "^5.0.0" } }, "sha512-K5Z2Su53ySQ46Fo2oZvOgGNU2+PKsK/d558QJoWoQl0tZ2GspXFONeCZ2cj0zMSIj6pYscQIMwSoZ+IKrtKygg=="],
 
-    "circuit-to-canvas": ["circuit-to-canvas@0.0.60", "", { "dependencies": { "transformation-matrix": "^3.1.0" }, "peerDependencies": { "@tscircuit/alphabet": "*", "typescript": "^5" } }, "sha512-SFekkpcZ2x3lumOmQqbMcVvDiw3M/OmQXu9Sdn8viXPLkQZyZ7wPfcgyfTCWNCTLAWJ9ge69+6tlWwlVm8Gj7w=="],
+    "circuit-to-canvas": ["circuit-to-canvas@0.0.61", "", { "dependencies": { "transformation-matrix": "^3.1.0" }, "peerDependencies": { "@tscircuit/alphabet": "*", "typescript": "^5" } }, "sha512-ILjX+P5ttfCVrUFmGtwFwDnc+b3zBv9NiyPhJ+uHLbEDOIqG5lhQBWdMgrgJdRPSw2OYYOXYgMxfGk4eRNjoVg=="],
 
     "circuit-to-svg": ["circuit-to-svg@0.0.271", "", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "calculate-elbow": "0.0.12", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" } }, "sha512-6g57xJT5lGiiSr29NIZztSwWhXq50ZXgwYbU2NCDLooZNXIz3d+sDrwhHltax53czFrt6w8q1om2XGPZHzAq6g=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@tscircuit/math-utils": "^0.0.29",
     "@vitejs/plugin-react": "^5.0.2",
     "circuit-json": "^0.0.356",
-    "circuit-to-canvas": "^0.0.60",
+    "circuit-to-canvas": "^0.0.61",
     "circuit-to-svg": "^0.0.271",
     "color": "^4.2.3",
     "react-supergrid": "^1.0.10",

--- a/src/lib/Drawer.ts
+++ b/src/lib/Drawer.ts
@@ -9,8 +9,8 @@ import {
 import colors from "./colors"
 import { scaleOnly } from "./util/scale-only"
 import { zIndexMap } from "./util/z-index-map"
-import { Rotation } from "circuit-json"
-import { BRepShape, Ring } from "lib/types"
+import type { Rotation } from "circuit-json"
+import type { BRepShape, Ring } from "lib/types"
 import colorParser from "color"
 
 export interface Aperture {
@@ -80,9 +80,9 @@ export const DEFAULT_DRAW_ORDER = [
   "bottom_silkscreen",
   "top",
   "soldermask_top",
-  "top_silkscreen",
   "soldermask_with_copper_bottom",
   "soldermask_with_copper_top",
+  "top_silkscreen",
   "board",
 ] as const
 
@@ -529,8 +529,8 @@ export class Drawer {
       ...(maskWithCopperLayerForForeground
         ? [maskWithCopperLayerForForeground]
         : []),
-      ...(associatedSilkscreen ? [associatedSilkscreen] : []),
       "drill",
+      ...(associatedSilkscreen ? [associatedSilkscreen] : []),
     ]
 
     order.forEach((layer, i) => {

--- a/src/lib/draw-pcb-smtpad.ts
+++ b/src/lib/draw-pcb-smtpad.ts
@@ -87,7 +87,7 @@ export function drawPcbSmtPadElementsForLayer({
   if (nonHighlightedElements.length > 0) {
     const drawer = new CircuitToCanvasDrawer(canvas)
     drawer.realToCanvasMat = realToCanvasMat
-    drawer.drawElements(nonHighlightedElements, { layers: [], drawSoldermask })
+    drawer.drawElements(nonHighlightedElements, { layers, drawSoldermask })
   }
 
   // Draw highlighted elements with lighter colors
@@ -96,7 +96,7 @@ export function drawPcbSmtPadElementsForLayer({
     highlightDrawer.configure({ colorOverrides: HOVER_COLOR_MAP })
     highlightDrawer.realToCanvasMat = realToCanvasMat
     highlightDrawer.drawElements(highlightedElements, {
-      layers: [],
+      layers,
       drawSoldermask,
     })
   }

--- a/src/lib/draw-soldermask.ts
+++ b/src/lib/draw-soldermask.ts
@@ -1,0 +1,85 @@
+import type { AnyCircuitElement, PcbRenderLayer } from "circuit-json"
+import {
+  CircuitToCanvasDrawer,
+  DEFAULT_PCB_COLOR_MAP,
+  type PcbColorMap,
+} from "circuit-to-canvas"
+import color from "color"
+import type { Matrix } from "transformation-matrix"
+import colors from "./colors"
+import type { Primitive } from "./types"
+
+const HOVER_SOLDERMASK_COLOR_MAP: PcbColorMap = {
+  ...DEFAULT_PCB_COLOR_MAP,
+  copper: {
+    ...DEFAULT_PCB_COLOR_MAP.copper,
+    top: color(colors.board.pad_front).lighten(0.5).toString(),
+    bottom: color(colors.board.pad_back).lighten(0.5).toString(),
+    inner1: color(colors.board.copper.in1).lighten(0.5).toString(),
+    inner2: color(colors.board.copper.in2).lighten(0.5).toString(),
+    inner3: color(colors.board.copper.in3).lighten(0.5).toString(),
+    inner4: color(colors.board.copper.in4).lighten(0.5).toString(),
+    inner5: color(colors.board.copper.in5).lighten(0.5).toString(),
+    inner6: color(colors.board.copper.in6).lighten(0.5).toString(),
+  },
+  soldermask: {
+    ...DEFAULT_PCB_COLOR_MAP.soldermask,
+    top: color(colors.board.soldermask.top).lighten(0.35).toString(),
+    bottom: color(colors.board.soldermask.bottom).lighten(0.35).toString(),
+  },
+}
+
+export function drawSoldermaskElementsForLayer({
+  canvas,
+  elements,
+  layers,
+  realToCanvasMat,
+  primitives,
+}: {
+  canvas: HTMLCanvasElement
+  elements: AnyCircuitElement[]
+  layers: PcbRenderLayer[]
+  realToCanvasMat: Matrix
+  primitives?: Primitive[]
+}) {
+  const drawer = new CircuitToCanvasDrawer(canvas)
+  drawer.realToCanvasMat = realToCanvasMat
+  drawer.drawElements(elements, { layers, drawSoldermask: true })
+
+  if (!primitives) return
+
+  const hoveredElementIds = new Set<string>()
+  for (const primitive of primitives) {
+    if (!(primitive.is_mouse_over || primitive.is_in_highlighted_net)) continue
+    const element = primitive._element
+    if (element?.type === "pcb_smtpad") {
+      hoveredElementIds.add(element.pcb_smtpad_id)
+    } else if (element?.type === "pcb_plated_hole") {
+      hoveredElementIds.add(element.pcb_plated_hole_id)
+    } else if (element?.type === "pcb_via") {
+      hoveredElementIds.add(element.pcb_via_id)
+    }
+  }
+
+  if (hoveredElementIds.size === 0) return
+
+  const hoveredElements = elements.filter((element) => {
+    if (element.type === "pcb_smtpad") {
+      return hoveredElementIds.has(element.pcb_smtpad_id)
+    }
+    if (element.type === "pcb_plated_hole") {
+      return hoveredElementIds.has(element.pcb_plated_hole_id)
+    }
+    if (element.type === "pcb_via") {
+      return hoveredElementIds.has(element.pcb_via_id)
+    }
+    return false
+  })
+
+  if (hoveredElements.length === 0) return
+
+  const hoverDrawer = new CircuitToCanvasDrawer(canvas)
+  hoverDrawer.configure({ colorOverrides: HOVER_SOLDERMASK_COLOR_MAP })
+  hoverDrawer.realToCanvasMat = realToCanvasMat
+  hoverDrawer.drawElements(hoveredElements, { layers, drawSoldermask: true })
+}

--- a/src/lib/draw-via.ts
+++ b/src/lib/draw-via.ts
@@ -29,12 +29,14 @@ export function drawPcbViaElementsForLayer({
   layers,
   realToCanvasMat,
   primitives,
+  drawSoldermask,
 }: {
   canvas: HTMLCanvasElement
   elements: AnyCircuitElement[]
   layers: PcbRenderLayer[]
   realToCanvasMat: Matrix
   primitives?: Primitive[]
+  drawSoldermask?: boolean
 }) {
   // Filter vias to only those on the specified layers
   const viaElements = elements.filter(isPcbVia).filter((element) => {
@@ -69,7 +71,7 @@ export function drawPcbViaElementsForLayer({
   if (nonHighlightedElements.length > 0) {
     const drawer = new CircuitToCanvasDrawer(canvas)
     drawer.realToCanvasMat = realToCanvasMat
-    drawer.drawElements(nonHighlightedElements, { layers })
+    drawer.drawElements(nonHighlightedElements, { layers, drawSoldermask })
   }
 
   // Draw highlighted elements with lighter colors
@@ -77,6 +79,9 @@ export function drawPcbViaElementsForLayer({
     const highlightDrawer = new CircuitToCanvasDrawer(canvas)
     highlightDrawer.configure({ colorOverrides: HOVER_COLOR_MAP })
     highlightDrawer.realToCanvasMat = realToCanvasMat
-    highlightDrawer.drawElements(highlightedElements, { layers })
+    highlightDrawer.drawElements(highlightedElements, {
+      layers,
+      drawSoldermask,
+    })
   }
 }


### PR DESCRIPTION
This PR fixes multiple long-standing PCB rendering issues by making soldermask a first-class, explicitly rendered layer and correcting drill/silkscreen ordering across the canvas pipeline.

Core changes:

Upgrades circuit-to-canvas to v0.0.61 to pick up corrected hole/soldermask semantics.

Introduces drawSoldermaskElementsForLayer to explicitly render soldermask per layer instead of relying on side effects.

Fixes drill rendering so holes are drawn first, then properly covered by soldermask (with margins), matching real PCB fabrication behavior.

Corrects layer and z-order sequencing (silkscreen vs soldermask vs drill) in both CanvasPrimitiveRenderer and Drawer.

Propagates drawSoldermask consistently to vias and SMT pads so soldermask behavior is uniform.

Adds hover highlighting for soldermask openings on pads, vias, and plated holes.

Result: accurate soldermask coverage, correct drill visibility, proper silkscreen ordering, and predictable hover behavior across all PCB layers.

https://pcb-viewer-git-fork-abse2001-main-tscircuit.vercel.app/?fixture=%7B%22path%22%3A%22src%2Fexamples%2F2025%2Fsolder-mask-smtpad.fixture.tsx%22%7D


https://pcb-viewer-git-fork-abse2001-main-tscircuit.vercel.app/?fixture=%7B%22path%22%3A%22src%2Fexamples%2F2025%2Fsoldermask-margin-comprehensive.fixture.tsx%22%7D


https://pcb-viewer-git-fork-abse2001-main-tscircuit.vercel.app/?fixture=%7B%22path%22%3A%22src%2Fexamples%2F2026%2Fasymmetric-soldermask-margin.fixture.tsx%22%7D