### PR TITLE
Fix edge_cuts visibility by elevating it above copper

### DIFF
--- a/src/lib/Drawer.ts
+++ b/src/lib/Drawer.ts
@@ -82,6 +82,7 @@ export const DEFAULT_DRAW_ORDER = [
   "soldermask_top",
   "soldermask_with_copper_bottom",
   "soldermask_with_copper_top",
+  "edge_cuts",
   "top_silkscreen",
   "board",
 ] as const
@@ -513,6 +514,7 @@ export class Drawer {
     const opaqueLayers = new Set<string>([
       foregroundLayer,
       "drill",
+      "edge_cuts",
       "other",
       "board",
       ...(associatedSilkscreen ? [associatedSilkscreen] : []),
@@ -524,6 +526,7 @@ export class Drawer {
 
     const layersToShiftToTop = [
       foregroundLayer,
+      "edge_cuts",
       ...(associatedSilkscreen ? [associatedSilkscreen] : []),
       ...(associatedNotes ? [associatedNotes] : []),
       ...(maskWithCopperLayerForForeground
@@ -537,6 +540,7 @@ export class Drawer {
       ...(maskWithCopperLayerForForeground
         ? [maskWithCopperLayerForForeground]
         : []),
+      "edge_cuts",
       "drill",
       ...(associatedSilkscreen ? [associatedSilkscreen] : []),
       ...(associatedNotes ? [associatedNotes] : []),


### PR DESCRIPTION
This change correctly integrates edge_cuts into the rendering pipeline by adding it to the default draw order and treating it as a first-class opaque layer. The layer is now consistently shifted to the top alongside foreground elements, ensuring board outlines are never obscured by soldermask, copper, or silkscreen. This fixes edge cut visibility issues and guarantees predictable, correct rendering across all layer combinations.