### PR TITLE
Fix invisible PCB board outlines by enforcing minimum 2px stroke width

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@tscircuit/pcb-viewer",
@@ -9,7 +10,7 @@
         "@tscircuit/math-utils": "^0.0.29",
         "@vitejs/plugin-react": "^5.0.2",
         "circuit-json": "^0.0.374",
-        "circuit-to-canvas": "^0.0.67",
+        "circuit-to-canvas": "^0.0.69",
         "circuit-to-svg": "^0.0.323",
         "color": "^4.2.3",
         "react-supergrid": "^1.0.10",
@@ -637,7 +638,7 @@
 
     "circuit-json-to-spice": ["circuit-json-to-spice@0.0.33", "", { "dependencies": { "circuit-json-to-connectivity-map": "^0.0.22" }, "peerDependencies": { "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "typescript": "^5.0.0" } }, "sha512-K5Z2Su53ySQ46Fo2oZvOgGNU2+PKsK/d558QJoWoQl0tZ2GspXFONeCZ2cj0zMSIj6pYscQIMwSoZ+IKrtKygg=="],
 
-    "circuit-to-canvas": ["circuit-to-canvas@0.0.67", "", { "dependencies": { "transformation-matrix": "^3.1.0" }, "peerDependencies": { "@tscircuit/alphabet": "*", "typescript": "^5" } }, "sha512-gML1zW6L/uBaEupRTsF4OT2cdcQKogyG8D9zdvnS8jC3mzFCOAam5hfeIqRAzH3KeB5oTLNrUOmyQbf4kwtKeA=="],
+    "circuit-to-canvas": ["circuit-to-canvas@0.0.69", "", { "dependencies": { "transformation-matrix": "^3.1.0" }, "peerDependencies": { "@tscircuit/alphabet": "*", "typescript": "^5" } }, "sha512-oL6OzDFb1JmETnvOIzLzFb+Jw/XfQQiLg7k1hYINvbq3NI1aIUHb8ROclEuXBW/BWeDUMWB6ctB4voDzC8DHtA=="],
 
     "circuit-to-svg": ["circuit-to-svg@0.0.323", "", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "calculate-elbow": "0.0.12", "debug": "^4.4.3", "svg-path-commander": "^2.1.11", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" }, "peerDependencies": { "@tscircuit/alphabet": "*" } }, "sha512-KtJJnvp75aTBPZZHqyFRTKciPDqEhJvFBqEg1ZvBrZy+TqPv+anUnJqWP4hg+2pW7lK/fYs9v4M6qsUiiBke0Q=="],
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@tscircuit/math-utils": "^0.0.29",
     "@vitejs/plugin-react": "^5.0.2",
     "circuit-json": "^0.0.374",
-    "circuit-to-canvas": "^0.0.67",
+    "circuit-to-canvas": "^0.0.69",
     "circuit-to-svg": "^0.0.323",
     "color": "^4.2.3",
     "react-supergrid": "^1.0.10",

--- a/src/lib/draw-pcb-board.ts
+++ b/src/lib/draw-pcb-board.ts
@@ -26,6 +26,10 @@ export function drawPcbBoardElements({
   const pcbBoardElements = elements.filter(isPcbBoardElement)
 
   for (const element of pcbBoardElements) {
-    drawer.drawElements([element], { layers, drawSoldermask })
+    drawer.drawElements([element], {
+      layers,
+      drawSoldermask,
+      minBoardOutlineStrokePx: 2,
+    })
   }
 }


### PR DESCRIPTION
PR Description:
Resolves TSC-345 (https://linear.app/tscircuit/issue/TSC-345/figure-out-how-to-make-board-outlines-more-visible-strokewidth-scaling)
Problem: Board outlines became too thin to see when zooming out, making it hard to visually identify PCB boundaries.
Solution: 
- Upgrade circuit-to-canvas to v0.0.69 (adds minBoardOutlineStrokePx support)
- Set minBoardOutlineStrokePx: 2 in drawPcbBoardElements() to ensure outlines remain at least 2px visible regardless of zoom level
Changes:
- package.json & bun.lock: Bump circuit-to-canvas from 0.0.67 → 0.0.69
- src/lib/draw-pcb-board.ts:32: Add minBoardOutlineStrokePx: 2 option to drawElements() call

<img width="1698" height="862" alt="Screenshot 2026-02-08 at 1 18 33 PM" src="https://github.com/user-attachments/assets/4b1309e3-0ba6-4da9-8fe2-9dda69301cfd" />
<img width="1655" height="586" alt="Screenshot 2026-02-08 at 1 24 17 PM" src="https://github.com/user-attachments/assets/dc46fbbd-50d2-4055-8b66-ff6550b4a80d" />
