### PR TITLE
feat: support manual board editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The PCBViewer component accepts these props:
 - `allowEditing`: Enable/disable editing capabilities (default: true)
 - `editEvents`: Array of edit events to apply
 - `onEditEventsChanged`: Callback when edit events change
+- `onBoardChanged`: Callback fired while the board is dragged or resized in `Edit Board` mode
 - `initialState`: Initial state for the viewer
 
 ### Features
@@ -82,6 +83,7 @@ The PCBViewer component accepts these props:
 - Interactive PCB viewing with pan and zoom
 - Multiple layer support (top, bottom, inner layers)
 - Component placement editing
+- Rectangular board dragging and resizing for boards with explicit `width`/`height`
 - Trace routing
 - DRC (Design Rule Check) visualization
 - Measurement tools

--- a/src/PCBViewer.tsx
+++ b/src/PCBViewer.tsx
@@ -14,6 +14,12 @@ import type { ManualEditEvent } from "@tscircuit/props"
 import { zIndexMap } from "lib/util/z-index-map"
 import { calculateCircuitJsonKey } from "lib/calculate-circuit-json-key"
 import { calculateBoardSizeKey } from "lib/calculate-board-size-key"
+import {
+  applyEditableBoard,
+  type EditableBoard,
+  getEditableBoard,
+  getEditableBoardKey,
+} from "lib/board-editing"
 
 const defaultTransform = compose(translate(400, 300), scale(40, -40))
 
@@ -24,6 +30,10 @@ type Props = {
   editEvents?: ManualEditEvent[]
   initialState?: Partial<StateProps>
   onEditEventsChanged?: (editEvents: ManualEditEvent[]) => void
+  onBoardChanged?: (
+    board: EditableBoard,
+    options: { inProgress: boolean },
+  ) => void
   focusOnHover?: boolean
   clickToInteractEnabled?: boolean
   debugGraphics?: GraphicsObject | null
@@ -38,6 +48,7 @@ export const PCBViewer = ({
   allowEditing = true,
   editEvents: editEventsProp,
   onEditEventsChanged,
+  onBoardChanged,
   focusOnHover = false,
   clickToInteractEnabled = false,
   disablePcbGroups = false,
@@ -58,6 +69,8 @@ export const PCBViewer = ({
   })
 
   let [editEvents, setEditEvents] = useState<ManualEditEvent[]>([])
+  const [editableBoardOverride, setEditableBoardOverride] =
+    useState<EditableBoard | null>(null)
   editEvents = editEventsProp ?? editEvents
 
   const initialRenderCompleted = useRef(false)
@@ -120,12 +133,30 @@ export const PCBViewer = ({
     )
   }, [circuitJsonKey])
 
+  const editableBoardKey = useMemo(
+    () => getEditableBoardKey(getEditableBoard(pcbElmsPreEdit)),
+    [pcbElmsPreEdit],
+  )
+
+  useEffect(() => {
+    setEditableBoardOverride(null)
+  }, [editableBoardKey])
+
   const elements = useMemo(() => {
-    return applyEditEvents({
+    const manualEditedElements = applyEditEvents({
       circuitJson: pcbElmsPreEdit as any,
       editEvents,
     })
-  }, [pcbElmsPreEdit, editEvents])
+
+    if (!editableBoardOverride) {
+      return manualEditedElements
+    }
+
+    return applyEditableBoard({
+      circuitJson: manualEditedElements as AnyCircuitElement[],
+      board: editableBoardOverride,
+    })
+  }, [pcbElmsPreEdit, editEvents, editableBoardOverride])
 
   const onCreateEditEvent = (event: ManualEditEvent) => {
     setEditEvents([...editEvents, event])
@@ -139,6 +170,14 @@ export const PCBViewer = ({
     )
     setEditEvents(newEditEvents)
     onEditEventsChanged?.(newEditEvents)
+  }
+
+  const handleBoardChanged = (
+    board: EditableBoard,
+    options: { inProgress: boolean },
+  ) => {
+    setEditableBoardOverride(board)
+    onBoardChanged?.(board, options)
   }
 
   const mergedInitialState = useMemo(
@@ -170,6 +209,7 @@ export const PCBViewer = ({
             cancelPanDrag={cancelPanDrag}
             onCreateEditEvent={onCreateEditEvent}
             onModifyEditEvent={onModifyEditEvent}
+            onBoardChanged={handleBoardChanged}
             grid={{
               spacing: 1,
               view_window: {

--- a/src/components/CanvasElementsRenderer.tsx
+++ b/src/components/CanvasElementsRenderer.tsx
@@ -10,6 +10,7 @@ import { CanvasPrimitiveRenderer } from "./CanvasPrimitiveRenderer"
 import { DebugGraphicsOverlay } from "./DebugGraphicsOverlay"
 import { WarningGraphicsOverlay } from "./WarningGraphicsOverlay"
 import { DimensionOverlay } from "./DimensionOverlay"
+import { EditBoardOverlay } from "./EditBoardOverlay"
 import { EditPlacementOverlay } from "./EditPlacementOverlay"
 import { EditTraceHintOverlay } from "./EditTraceHintOverlay"
 import { ErrorOverlay } from "./ErrorOverlay"
@@ -19,6 +20,7 @@ import { RatsNestOverlay } from "./RatsNestOverlay"
 import { ToolbarOverlay } from "./ToolbarOverlay"
 import type { ManualEditEvent } from "@tscircuit/props"
 import { useGlobalStore } from "../global-store"
+import type { EditableBoard } from "lib/board-editing"
 
 export interface CanvasElementsRendererProps {
   elements: AnyCircuitElement[]
@@ -32,10 +34,15 @@ export interface CanvasElementsRendererProps {
   cancelPanDrag: () => void
   onCreateEditEvent: (event: ManualEditEvent) => void
   onModifyEditEvent: (event: Partial<ManualEditEvent>) => void
+  onBoardChanged?: (
+    board: EditableBoard,
+    options: { inProgress: boolean },
+  ) => void
 }
 
 export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
   const { transform, elements } = props
+  const onBoardChanged = props.onBoardChanged ?? (() => {})
   const hoveredErrorId = useGlobalStore((state) => state.hovered_error_id)
   const isShowingCopperPours = useGlobalStore(
     (state) => state.is_showing_copper_pours,
@@ -165,60 +172,68 @@ export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
       primitives={primitivesWithoutInteractionMetadata}
       onMouseHoverOverPrimitives={onMouseOverPrimitives}
     >
-      <EditPlacementOverlay
+      <EditBoardOverlay
         disabled={!props.allowEditing}
         transform={transform}
         soup={elements}
         cancelPanDrag={props.cancelPanDrag}
-        onCreateEditEvent={props.onCreateEditEvent}
-        onModifyEditEvent={props.onModifyEditEvent}
+        onBoardChanged={onBoardChanged}
       >
-        <EditTraceHintOverlay
+        <EditPlacementOverlay
           disabled={!props.allowEditing}
           transform={transform}
           soup={elements}
           cancelPanDrag={props.cancelPanDrag}
-          onCreateEditEvent={props.onCreateEditEvent as any}
-          onModifyEditEvent={props.onModifyEditEvent as any}
+          onCreateEditEvent={props.onCreateEditEvent}
+          onModifyEditEvent={props.onModifyEditEvent}
         >
-          <DimensionOverlay
-            transform={transform!}
-            focusOnHover={props.focusOnHover}
-            primitives={primitivesWithoutInteractionMetadata}
+          <EditTraceHintOverlay
+            disabled={!props.allowEditing}
+            transform={transform}
+            soup={elements}
+            cancelPanDrag={props.cancelPanDrag}
+            onCreateEditEvent={props.onCreateEditEvent as any}
+            onModifyEditEvent={props.onModifyEditEvent as any}
           >
-            <ToolbarOverlay elements={elements}>
-              <ErrorOverlay transform={transform} elements={elements}>
-                <RatsNestOverlay transform={transform} soup={elements}>
-                  <PcbGroupOverlay
-                    transform={transform}
-                    elements={elements}
-                    hoveredComponentIds={hoveredComponentIds}
-                  >
-                    <DebugGraphicsOverlay
+            <DimensionOverlay
+              transform={transform!}
+              focusOnHover={props.focusOnHover}
+              primitives={primitivesWithoutInteractionMetadata}
+            >
+              <ToolbarOverlay elements={elements}>
+                <ErrorOverlay transform={transform} elements={elements}>
+                  <RatsNestOverlay transform={transform} soup={elements}>
+                    <PcbGroupOverlay
                       transform={transform}
-                      debugGraphics={props.debugGraphics}
+                      elements={elements}
+                      hoveredComponentIds={hoveredComponentIds}
                     >
-                      <WarningGraphicsOverlay
+                      <DebugGraphicsOverlay
                         transform={transform}
-                        elements={elements}
+                        debugGraphics={props.debugGraphics}
                       >
-                        <CanvasPrimitiveRenderer
+                        <WarningGraphicsOverlay
                           transform={transform}
-                          primitives={primitives}
-                          elements={elementsToRender}
-                          width={props.width}
-                          height={props.height}
-                          grid={props.grid}
-                        />
-                      </WarningGraphicsOverlay>
-                    </DebugGraphicsOverlay>
-                  </PcbGroupOverlay>
-                </RatsNestOverlay>
-              </ErrorOverlay>
-            </ToolbarOverlay>
-          </DimensionOverlay>
-        </EditTraceHintOverlay>
-      </EditPlacementOverlay>
+                          elements={elements}
+                        >
+                          <CanvasPrimitiveRenderer
+                            transform={transform}
+                            primitives={primitives}
+                            elements={elementsToRender}
+                            width={props.width}
+                            height={props.height}
+                            grid={props.grid}
+                          />
+                        </WarningGraphicsOverlay>
+                      </DebugGraphicsOverlay>
+                    </PcbGroupOverlay>
+                  </RatsNestOverlay>
+                </ErrorOverlay>
+              </ToolbarOverlay>
+            </DimensionOverlay>
+          </EditTraceHintOverlay>
+        </EditPlacementOverlay>
+      </EditBoardOverlay>
     </MouseElementTracker>
   )
 }

--- a/src/components/EditBoardOverlay.tsx
+++ b/src/components/EditBoardOverlay.tsx
@@ -1,0 +1,295 @@
+import type { AnyCircuitElement } from "circuit-json"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { applyToPoint, identity, inverse } from "transformation-matrix"
+import type { Matrix } from "transformation-matrix"
+import { useGlobalStore } from "../global-store"
+import {
+  type EditableBoard,
+  type ResizeHandle,
+  getEditableBoard,
+  resizeEditableBoard,
+} from "../lib/board-editing"
+
+interface Props {
+  transform?: Matrix
+  children: React.ReactNode
+  soup: AnyCircuitElement[]
+  disabled?: boolean
+  cancelPanDrag: () => void
+  onBoardChanged: (
+    board: EditableBoard,
+    options: { inProgress: boolean },
+  ) => void
+}
+
+type DragState =
+  | {
+      mode: "move"
+      dragStart: { x: number; y: number }
+      originalBoard: EditableBoard
+    }
+  | {
+      mode: "resize"
+      dragStart: { x: number; y: number }
+      originalBoard: EditableBoard
+      handle: ResizeHandle
+    }
+
+const HANDLE_SIZE = 12
+
+const HANDLE_CONFIGS: Array<{
+  handle: ResizeHandle
+  cursor: React.CSSProperties["cursor"]
+  xFactor: number
+  yFactor: number
+}> = [
+  { handle: "nw", cursor: "nwse-resize", xFactor: 0, yFactor: 0 },
+  { handle: "n", cursor: "ns-resize", xFactor: 0.5, yFactor: 0 },
+  { handle: "ne", cursor: "nesw-resize", xFactor: 1, yFactor: 0 },
+  { handle: "e", cursor: "ew-resize", xFactor: 1, yFactor: 0.5 },
+  { handle: "se", cursor: "nwse-resize", xFactor: 1, yFactor: 1 },
+  { handle: "s", cursor: "ns-resize", xFactor: 0.5, yFactor: 1 },
+  { handle: "sw", cursor: "nesw-resize", xFactor: 0, yFactor: 1 },
+  { handle: "w", cursor: "ew-resize", xFactor: 0, yFactor: 0.5 },
+]
+
+const formatMm = (value: number) => {
+  return Number.isInteger(value) ? `${value}` : value.toFixed(1)
+}
+
+export const EditBoardOverlay = ({
+  children,
+  disabled: disabledProp,
+  transform,
+  soup,
+  cancelPanDrag,
+  onBoardChanged,
+}: Props) => {
+  if (!transform) transform = identity()
+
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const [dragState, setDragState] = useState<DragState | null>(null)
+  const inEditBoardMode = useGlobalStore((state) => state.in_edit_board_mode)
+  const editableBoard = useMemo(() => getEditableBoard(soup), [soup])
+  const disabled = disabledProp || !inEditBoardMode || !editableBoard
+
+  const boardRect = useMemo(() => {
+    if (!editableBoard) return null
+
+    const topLeft = applyToPoint(transform, {
+      x: editableBoard.center.x - editableBoard.width / 2,
+      y: editableBoard.center.y + editableBoard.height / 2,
+    })
+    const bottomRight = applyToPoint(transform, {
+      x: editableBoard.center.x + editableBoard.width / 2,
+      y: editableBoard.center.y - editableBoard.height / 2,
+    })
+
+    const left = Math.min(topLeft.x, bottomRight.x)
+    const top = Math.min(topLeft.y, bottomRight.y)
+    const right = Math.max(topLeft.x, bottomRight.x)
+    const bottom = Math.max(topLeft.y, bottomRight.y)
+
+    return {
+      left,
+      top,
+      width: right - left,
+      height: bottom - top,
+      bottom,
+    }
+  }, [editableBoard, transform])
+
+  useEffect(() => {
+    if (!dragState || !containerRef.current) return
+
+    const getRealWorldPoint = (event: MouseEvent) => {
+      const rect = containerRef.current?.getBoundingClientRect()
+      if (!rect) return null
+
+      const point = {
+        x: event.clientX - rect.left,
+        y: event.clientY - rect.top,
+      }
+
+      if (Number.isNaN(point.x) || Number.isNaN(point.y)) return null
+      return applyToPoint(inverse(transform), point)
+    }
+
+    const onMouseMove = (event: MouseEvent) => {
+      const point = getRealWorldPoint(event)
+      if (!point) return
+
+      const delta = {
+        x: point.x - dragState.dragStart.x,
+        y: point.y - dragState.dragStart.y,
+      }
+
+      const nextBoard =
+        dragState.mode === "move"
+          ? {
+              ...dragState.originalBoard,
+              center: {
+                x: dragState.originalBoard.center.x + delta.x,
+                y: dragState.originalBoard.center.y + delta.y,
+              },
+            }
+          : resizeEditableBoard({
+              board: dragState.originalBoard,
+              handle: dragState.handle,
+              delta,
+            })
+
+      onBoardChanged(nextBoard, { inProgress: true })
+    }
+
+    const onMouseUp = (event: MouseEvent) => {
+      const point = getRealWorldPoint(event)
+      let finalBoard = dragState.originalBoard
+
+      if (point) {
+        const delta = {
+          x: point.x - dragState.dragStart.x,
+          y: point.y - dragState.dragStart.y,
+        }
+
+        finalBoard =
+          dragState.mode === "move"
+            ? {
+                ...dragState.originalBoard,
+                center: {
+                  x: dragState.originalBoard.center.x + delta.x,
+                  y: dragState.originalBoard.center.y + delta.y,
+                },
+              }
+            : resizeEditableBoard({
+                board: dragState.originalBoard,
+                handle: dragState.handle,
+                delta,
+              })
+      }
+
+      onBoardChanged(finalBoard, { inProgress: false })
+      setDragState(null)
+    }
+
+    window.addEventListener("mousemove", onMouseMove)
+    window.addEventListener("mouseup", onMouseUp)
+
+    return () => {
+      window.removeEventListener("mousemove", onMouseMove)
+      window.removeEventListener("mouseup", onMouseUp)
+    }
+  }, [dragState, onBoardChanged, transform])
+
+  useEffect(() => {
+    if (!disabled) return
+    setDragState(null)
+  }, [disabled])
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        position: "relative",
+        overflow: "hidden",
+      }}
+    >
+      {children}
+      {!disabled && editableBoard && boardRect && (
+        <>
+          <div
+            style={{
+              position: "absolute",
+              left: boardRect.left,
+              top: boardRect.top,
+              width: boardRect.width,
+              height: boardRect.height,
+              border: "1px dashed rgba(107, 221, 143, 0.95)",
+              backgroundColor:
+                dragState?.mode === "move"
+                  ? "rgba(107, 221, 143, 0.08)"
+                  : "rgba(107, 221, 143, 0.02)",
+              cursor: "move",
+              boxSizing: "border-box",
+            }}
+            onMouseDown={(event) => {
+              event.preventDefault()
+              cancelPanDrag()
+
+              const rect = containerRef.current?.getBoundingClientRect()
+              if (!rect) return
+
+              setDragState({
+                mode: "move",
+                dragStart: applyToPoint(inverse(transform), {
+                  x: event.clientX - rect.left,
+                  y: event.clientY - rect.top,
+                }),
+                originalBoard: editableBoard,
+              })
+            }}
+          />
+
+          {HANDLE_CONFIGS.map((config) => (
+            <div
+              key={config.handle}
+              style={{
+                position: "absolute",
+                left: boardRect.left + boardRect.width * config.xFactor,
+                top: boardRect.top + boardRect.height * config.yFactor,
+                width: HANDLE_SIZE,
+                height: HANDLE_SIZE,
+                transform: "translate(-50%, -50%)",
+                borderRadius: 999,
+                border: "2px solid rgba(107, 221, 143, 0.95)",
+                backgroundColor: "#0d180f",
+                boxSizing: "border-box",
+                cursor: config.cursor,
+              }}
+              onMouseDown={(event) => {
+                event.preventDefault()
+                event.stopPropagation()
+                cancelPanDrag()
+
+                const rect = containerRef.current?.getBoundingClientRect()
+                if (!rect) return
+
+                setDragState({
+                  mode: "resize",
+                  handle: config.handle,
+                  dragStart: applyToPoint(inverse(transform), {
+                    x: event.clientX - rect.left,
+                    y: event.clientY - rect.top,
+                  }),
+                  originalBoard: editableBoard,
+                })
+              }}
+            />
+          ))}
+
+          <div
+            style={{
+              position: "absolute",
+              left: boardRect.left + boardRect.width / 2,
+              top: boardRect.bottom + 12,
+              transform: "translateX(-50%)",
+              backgroundColor: "rgba(12, 17, 13, 0.9)",
+              color: "#d9fbe2",
+              border: "1px solid rgba(107, 221, 143, 0.35)",
+              borderRadius: 999,
+              padding: "4px 10px",
+              fontSize: 11,
+              fontFamily: "sans-serif",
+              whiteSpace: "nowrap",
+              pointerEvents: "none",
+            }}
+          >
+            {formatMm(editableBoard.width)}mm × {formatMm(editableBoard.height)}
+            mm · center ({formatMm(editableBoard.center.x)},{" "}
+            {formatMm(editableBoard.center.y)})
+          </div>
+        </>
+      )}
+    </div>
+  )
+}

--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -255,6 +255,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     editModes: {
       in_move_footprint_mode: s.in_move_footprint_mode,
       in_draw_trace_mode: s.in_draw_trace_mode,
+      in_edit_board_mode: s.in_edit_board_mode,
     },
     viewSettings: {
       is_showing_rats_nest: s.is_showing_rats_nest,
@@ -314,6 +315,8 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
   // Find the PCB board to get the number of layers
   const pcbBoard = elements?.find((el) => el.type === "pcb_board") as any
   const numLayers = pcbBoard?.num_layers || 2
+  const hasEditableBoard =
+    Number.isFinite(pcbBoard?.width) && Number.isFinite(pcbBoard?.height)
 
   // Filter layers based on PCB layer count
   const availableLayers =
@@ -432,6 +435,10 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
   const handleMoveComponentToggle = useCallback(() => {
     setEditMode(editModes.in_move_footprint_mode ? "off" : "move_footprint")
   }, [editModes.in_move_footprint_mode, setEditMode])
+
+  const handleEditBoardToggle = useCallback(() => {
+    setEditMode(editModes.in_edit_board_mode ? "off" : "edit_board")
+  }, [editModes.in_edit_board_mode, setEditMode])
 
   const handleRatsNestToggle = useCallback(() => {
     setIsShowingRatsNest(!viewSettings.is_showing_rats_nest)
@@ -740,6 +747,20 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
             Move Components
           </div>
         </ToolbarButton>
+        {hasEditableBoard && (
+          <ToolbarButton
+            isSmallScreen={isSmallScreen}
+            style={
+              editModes.in_edit_board_mode ? { backgroundColor: "#444" } : {}
+            }
+            onClick={handleEditBoardToggle}
+          >
+            <div>
+              {editModes.in_edit_board_mode ? "✖ " : ""}
+              Edit Board
+            </div>
+          </ToolbarButton>
+        )}
         <ToolbarButton
           isSmallScreen={isSmallScreen}
           style={{}}

--- a/src/examples/2026/manual-edit-board.fixture.tsx
+++ b/src/examples/2026/manual-edit-board.fixture.tsx
@@ -1,0 +1,110 @@
+import { useMemo, useState } from "react"
+import type { AnyCircuitElement } from "circuit-json"
+import { PCBViewer } from "../../PCBViewer"
+import type { EditableBoard } from "../../lib/board-editing"
+
+const createCircuit = (): AnyCircuitElement[] => {
+  return [
+    {
+      type: "pcb_board",
+      pcb_board_id: "board-main",
+      center: { x: 0, y: 0 },
+      width: 40,
+      height: 24,
+    } as any,
+    {
+      type: "pcb_component",
+      pcb_component_id: "u1",
+      center: { x: -8, y: 2 },
+      width: 6,
+      height: 6,
+      layer: "top",
+      rotation: 0,
+    } as any,
+    {
+      type: "pcb_component",
+      pcb_component_id: "r1",
+      center: { x: 12, y: -4 },
+      width: 4,
+      height: 2,
+      layer: "top",
+      rotation: 0,
+    } as any,
+  ]
+}
+
+export const ManualEditBoard = () => {
+  const circuitJson = useMemo(() => createCircuit(), [])
+  const [boardState, setBoardState] = useState<EditableBoard | null>(null)
+  const [status, setStatus] = useState(
+    "Toggle Edit Board, then drag the board or a handle.",
+  )
+
+  return (
+    <div
+      style={{
+        display: "grid",
+        gap: 16,
+      }}
+    >
+      <div
+        style={{
+          padding: 16,
+          background: "#121212",
+          color: "#f5f5f5",
+          borderRadius: 10,
+          fontFamily: "sans-serif",
+        }}
+      >
+        <h2 style={{ marginTop: 0 }}>Manual Board Editing</h2>
+        <p style={{ opacity: 0.8, marginBottom: 12 }}>
+          Use the <strong>Edit Board</strong> toolbar mode to resize the board
+          from any edge or corner, or drag the board body to offset it relative
+          to the placed parts.
+        </p>
+        <div
+          style={{
+            display: "grid",
+            gap: 8,
+            fontSize: 13,
+            background: "#1d1d1d",
+            borderRadius: 8,
+            padding: 12,
+          }}
+        >
+          <div>Status: {status}</div>
+          <div>
+            Board:{" "}
+            {boardState
+              ? `${boardState.width.toFixed(1)}mm × ${boardState.height.toFixed(
+                  1,
+                )}mm at (${boardState.center.x.toFixed(
+                  1,
+                )}, ${boardState.center.y.toFixed(1)})`
+              : "No edits yet"}
+          </div>
+        </div>
+      </div>
+
+      <div
+        style={{
+          height: 520,
+          borderRadius: 10,
+          overflow: "hidden",
+          border: "1px solid #2d2d2d",
+        }}
+      >
+        <PCBViewer
+          circuitJson={circuitJson}
+          height={520}
+          onBoardChanged={(board, options) => {
+            setBoardState(board)
+            setStatus(
+              options.inProgress ? "Editing board..." : "Board edit complete.",
+            )
+          }}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/examples/2026/sparkfun-boards.fixture.tsx
+++ b/src/examples/2026/sparkfun-boards.fixture.tsx
@@ -2,113 +2,99 @@ import type React from "react"
 import { PCBViewer } from "../../PCBViewer"
 
 export const SparkfunBoards: React.FC = () => {
-
   return (
     <div style={{ backgroundColor: "black", width: "100%", height: "700px" }}>
-      <PCBViewer circuitJson={[
-  {
-    "type": "pcb_plated_hole",
-    "pcb_plated_hole_id": "pcb_plated_hole_0",
-    "pcb_component_id": "pcb_component_0",
-    "pcb_port_id": "pcb_port_0",
-    "outer_diameter": 1.88,
-    "hole_diameter": 1.016,
-    "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole1",
-      "pin1"
-    ],
-    "x": -8,
-    "y": 0,
-    "layers": [
-      "top",
-      "bottom"
-    ],
-    "is_covered_with_solder_mask": false,
-    "subcircuit_id": "subcircuit_source_group_0",
-  },
-  {
-    "type": "pcb_plated_hole",
-    "pcb_plated_hole_id": "pcb_plated_hole_5",
-    "pcb_component_id": "pcb_component_1",
-    "pcb_port_id": "pcb_port_5",
-    "outer_diameter": 1.88,
-    "hole_diameter": 1.016,
-    "shape": "circle",
-    "port_hints": [
-      "unnamed_platedhole6",
-      "1"
-    ],
-    "x": 8,
-    "y": 0,
-    "layers": [
-      "top",
-      "bottom"
-    ],
-    "is_covered_with_solder_mask": false,
-    "subcircuit_id": "subcircuit_source_group_0"
-  },
-  {
-    "type": "pcb_trace",
-    "pcb_trace_id": "source_net_0_0",
-    "route": [
-      {
-        "route_type": "wire",
-        "x": 8,
-        "y": 0,
-        "width": 0.15,
-        "layer": "bottom",
-        "start_pcb_port_id": "pcb_port_5"
-      },
-      {
-        "route_type": "wire",
-        "x": 0,
-        "y": 0,
-        "width": 0.15,
-        "layer": "bottom"
-      },
-      {
-        "route_type": "via",
-        "x": 0,
-        "y": 0,
-        "from_layer": "bottom",
-        "to_layer": "top"
-      },
-      {
-        "route_type": "wire",
-        "x": 0,
-        "y": 0,
-        "width": 0.15,
-        "layer": "top"
-      },
-      {
-        "route_type": "wire",
-        "x": -8,
-        "y": 0,
-        "width": 0.15,
-        "layer": "top",
-        "end_pcb_port_id": "pcb_port_0"
-      }
-    ],
-    "subcircuit_id": "subcircuit_source_group_0",
-    "source_trace_id": "source_net_0"
-  },
-  {
-    "type": "pcb_via",
-    "pcb_via_id": "pcb_via_0",
-    "pcb_trace_id": "source_net_0_0",
-    "x": 0,
-    "y": 0,
-    "hole_diameter": 0.2,
-    "outer_diameter": 0.3,
-    "layers": [
-      "bottom",
-      "top"
-    ],
-    "from_layer": "bottom",
-    "to_layer": "top"
-  }
-]} />
+      <PCBViewer
+        circuitJson={[
+          {
+            type: "pcb_plated_hole",
+            pcb_plated_hole_id: "pcb_plated_hole_0",
+            pcb_component_id: "pcb_component_0",
+            pcb_port_id: "pcb_port_0",
+            outer_diameter: 1.88,
+            hole_diameter: 1.016,
+            shape: "circle",
+            port_hints: ["unnamed_platedhole1", "pin1"],
+            x: -8,
+            y: 0,
+            layers: ["top", "bottom"],
+            is_covered_with_solder_mask: false,
+            subcircuit_id: "subcircuit_source_group_0",
+          },
+          {
+            type: "pcb_plated_hole",
+            pcb_plated_hole_id: "pcb_plated_hole_5",
+            pcb_component_id: "pcb_component_1",
+            pcb_port_id: "pcb_port_5",
+            outer_diameter: 1.88,
+            hole_diameter: 1.016,
+            shape: "circle",
+            port_hints: ["unnamed_platedhole6", "1"],
+            x: 8,
+            y: 0,
+            layers: ["top", "bottom"],
+            is_covered_with_solder_mask: false,
+            subcircuit_id: "subcircuit_source_group_0",
+          },
+          {
+            type: "pcb_trace",
+            pcb_trace_id: "source_net_0_0",
+            route: [
+              {
+                route_type: "wire",
+                x: 8,
+                y: 0,
+                width: 0.15,
+                layer: "bottom",
+                start_pcb_port_id: "pcb_port_5",
+              },
+              {
+                route_type: "wire",
+                x: 0,
+                y: 0,
+                width: 0.15,
+                layer: "bottom",
+              },
+              {
+                route_type: "via",
+                x: 0,
+                y: 0,
+                from_layer: "bottom",
+                to_layer: "top",
+              },
+              {
+                route_type: "wire",
+                x: 0,
+                y: 0,
+                width: 0.15,
+                layer: "top",
+              },
+              {
+                route_type: "wire",
+                x: -8,
+                y: 0,
+                width: 0.15,
+                layer: "top",
+                end_pcb_port_id: "pcb_port_0",
+              },
+            ],
+            subcircuit_id: "subcircuit_source_group_0",
+            source_trace_id: "source_net_0",
+          },
+          {
+            type: "pcb_via",
+            pcb_via_id: "pcb_via_0",
+            pcb_trace_id: "source_net_0_0",
+            x: 0,
+            y: 0,
+            hole_diameter: 0.2,
+            outer_diameter: 0.3,
+            layers: ["bottom", "top"],
+            from_layer: "bottom",
+            to_layer: "top",
+          },
+        ]}
+      />
     </div>
   )
 }

--- a/src/global-store.ts
+++ b/src/global-store.ts
@@ -22,6 +22,7 @@ export interface State {
   in_edit_mode: boolean
   in_move_footprint_mode: boolean
   in_draw_trace_mode: boolean
+  in_edit_board_mode: boolean
   is_mouse_over_container: boolean
   is_moving_component: boolean
   is_drawing_trace: boolean
@@ -40,7 +41,9 @@ export interface State {
   hovered_error_id: string | null
 
   selectLayer: (layer: LayerRef) => void
-  setEditMode: (mode: "off" | "move_footprint" | "draw_trace") => void
+  setEditMode: (
+    mode: "off" | "move_footprint" | "draw_trace" | "edit_board",
+  ) => void
   setIsMovingComponent: (is_moving: boolean) => void
   setIsDrawingTrace: (is_drawing: boolean) => void
   setIsShowingRatsNest: (is_showing: boolean) => void
@@ -78,6 +81,7 @@ export const createStore = (
         in_edit_mode: false,
         in_move_footprint_mode: false,
         in_draw_trace_mode: false,
+        in_edit_board_mode: false,
 
         is_moving_component: false,
         is_drawing_trace: false,
@@ -122,6 +126,7 @@ export const createStore = (
             in_edit_mode: mode !== "off",
             in_move_footprint_mode: mode === "move_footprint",
             in_draw_trace_mode: mode === "draw_trace",
+            in_edit_board_mode: mode === "edit_board",
             is_moving_component: false,
             is_drawing_trace: false,
           }),

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,3 @@
 export * from "./PCBViewer"
 export { CanvasElementsRenderer } from "./components/CanvasElementsRenderer"
+export type { EditableBoard } from "./lib/board-editing"

--- a/src/lib/board-editing.ts
+++ b/src/lib/board-editing.ts
@@ -1,0 +1,127 @@
+import type { AnyCircuitElement, PcbBoard } from "circuit-json"
+
+export type EditableBoard = {
+  pcb_board_id: string
+  center: { x: number; y: number }
+  width: number
+  height: number
+}
+
+export type ResizeHandle = "n" | "ne" | "e" | "se" | "s" | "sw" | "w" | "nw"
+
+const MIN_BOARD_DIMENSION = 1
+
+export const getEditableBoard = (
+  circuitJson?: AnyCircuitElement[],
+): EditableBoard | null => {
+  if (!circuitJson) return null
+
+  const board = circuitJson.find((element): element is PcbBoard => {
+    return (
+      element.type === "pcb_board" &&
+      Number.isFinite(element.width) &&
+      Number.isFinite(element.height)
+    )
+  })
+
+  if (
+    !board?.pcb_board_id ||
+    !board.center ||
+    !Number.isFinite(board.width) ||
+    !Number.isFinite(board.height)
+  ) {
+    return null
+  }
+
+  const width = board.width as number
+  const height = board.height as number
+
+  return {
+    pcb_board_id: board.pcb_board_id,
+    center: { ...board.center },
+    width,
+    height,
+  }
+}
+
+export const getEditableBoardKey = (board: EditableBoard | null): string => {
+  if (!board) return "no-editable-board"
+
+  return [
+    board.pcb_board_id,
+    board.center.x,
+    board.center.y,
+    board.width,
+    board.height,
+  ].join(":")
+}
+
+export const applyEditableBoard = ({
+  circuitJson,
+  board,
+}: {
+  circuitJson: AnyCircuitElement[]
+  board: EditableBoard
+}): AnyCircuitElement[] => {
+  return circuitJson.map((element) => {
+    if (
+      element.type !== "pcb_board" ||
+      element.pcb_board_id !== board.pcb_board_id
+    ) {
+      return element
+    }
+
+    return {
+      ...element,
+      center: { ...board.center },
+      width: board.width,
+      height: board.height,
+    } satisfies PcbBoard
+  })
+}
+
+export const resizeEditableBoard = ({
+  board,
+  handle,
+  delta,
+}: {
+  board: EditableBoard
+  handle: ResizeHandle
+  delta: { x: number; y: number }
+}): EditableBoard => {
+  let left = board.center.x - board.width / 2
+  let right = board.center.x + board.width / 2
+  let top = board.center.y + board.height / 2
+  let bottom = board.center.y - board.height / 2
+
+  if (handle.includes("w")) left += delta.x
+  if (handle.includes("e")) right += delta.x
+  if (handle.includes("n")) top += delta.y
+  if (handle.includes("s")) bottom += delta.y
+
+  if (right - left < MIN_BOARD_DIMENSION) {
+    if (handle.includes("w")) {
+      left = right - MIN_BOARD_DIMENSION
+    } else if (handle.includes("e")) {
+      right = left + MIN_BOARD_DIMENSION
+    }
+  }
+
+  if (top - bottom < MIN_BOARD_DIMENSION) {
+    if (handle.includes("s")) {
+      bottom = top - MIN_BOARD_DIMENSION
+    } else if (handle.includes("n")) {
+      top = bottom + MIN_BOARD_DIMENSION
+    }
+  }
+
+  return {
+    ...board,
+    center: {
+      x: (left + right) / 2,
+      y: (top + bottom) / 2,
+    },
+    width: right - left,
+    height: top - bottom,
+  }
+}

--- a/tests/lib/board-editing.test.ts
+++ b/tests/lib/board-editing.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import {
+  applyEditableBoard,
+  getEditableBoard,
+  resizeEditableBoard,
+} from "../../src/lib/board-editing"
+
+describe("board-editing helpers", () => {
+  it("finds the first board with explicit width and height", () => {
+    const circuitJson: AnyCircuitElement[] = [
+      {
+        type: "pcb_board",
+        pcb_board_id: "outline-only",
+        center: { x: 0, y: 0 },
+        outline: [
+          { x: -5, y: -5 },
+          { x: 5, y: -5 },
+          { x: 5, y: 5 },
+        ],
+      } as any,
+      {
+        type: "pcb_board",
+        pcb_board_id: "editable",
+        center: { x: 4, y: -3 },
+        width: 40,
+        height: 20,
+      } as any,
+    ]
+
+    expect(getEditableBoard(circuitJson)).toEqual({
+      pcb_board_id: "editable",
+      center: { x: 4, y: -3 },
+      width: 40,
+      height: 20,
+    })
+  })
+
+  it("updates board center and dimensions without touching other elements", () => {
+    const circuitJson: AnyCircuitElement[] = [
+      {
+        type: "pcb_board",
+        pcb_board_id: "board-1",
+        center: { x: 0, y: 0 },
+        width: 20,
+        height: 10,
+      } as any,
+      {
+        type: "pcb_component",
+        pcb_component_id: "comp-1",
+        center: { x: 2, y: 3 },
+        width: 1,
+        height: 1,
+      } as any,
+    ]
+
+    const nextCircuit = applyEditableBoard({
+      circuitJson,
+      board: {
+        pcb_board_id: "board-1",
+        center: { x: 5, y: -2 },
+        width: 24,
+        height: 12,
+      },
+    })
+
+    expect(nextCircuit[0]).toMatchObject({
+      type: "pcb_board",
+      center: { x: 5, y: -2 },
+      width: 24,
+      height: 12,
+    })
+    expect(nextCircuit[1]).toMatchObject({
+      type: "pcb_component",
+      center: { x: 2, y: 3 },
+    })
+  })
+
+  it("resizes around the opposite edge for corner handles", () => {
+    const board = {
+      pcb_board_id: "board-1",
+      center: { x: 0, y: 0 },
+      width: 20,
+      height: 10,
+    }
+
+    expect(
+      resizeEditableBoard({
+        board,
+        handle: "ne",
+        delta: { x: 6, y: 4 },
+      }),
+    ).toEqual({
+      pcb_board_id: "board-1",
+      center: { x: 3, y: 2 },
+      width: 26,
+      height: 14,
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add an `Edit Board` mode for boards with explicit `width`/`height`
- support dragging the board body to offset its center and dragging edge/corner handles to resize it
- expose board edits through `onBoardChanged`, add a dedicated fixture, and cover the board edit helpers with tests
- include the repo formatter change required to keep `format:check` green

/claim #106

## Testing
- `npx tsc --noEmit`
- `npm run build`
- `npm run format:check`

## Demo
- [manual-edit-board-demo.mp4](https://github.com/javery556/pcb-viewer/releases/download/demo-manual-board-editing-20260315/manual-edit-board-demo.mp4)