### PR TITLE
Remove thick red outline on pcb keepouts

### DIFF
--- a/src/lib/draw-pcb-keepout.ts
+++ b/src/lib/draw-pcb-keepout.ts
@@ -2,8 +2,6 @@ import { CircuitToCanvasDrawer } from "circuit-to-canvas"
 import type { AnyCircuitElement } from "circuit-json"
 import type { Matrix } from "transformation-matrix"
 
-// Color map for keepouts - uses background color for all layers
-
 export function isPcbKeepout(element: AnyCircuitElement) {
   return element.type === "pcb_keepout"
 }
@@ -26,6 +24,13 @@ export function drawPcbKeepoutElementsForLayer({
 
   const drawer = new CircuitToCanvasDrawer(canvas)
   drawer.realToCanvasMat = realToCanvasMat
+
+  // Use a subtle gray color instead of the default bright red outline
+  drawer.configure({
+    colorOverrides: {
+      keepout: "rgba(255, 255, 255, 0.25)",
+    },
+  })
 
   drawer.drawElements(keepoutElements, { layers: [] })
 }


### PR DESCRIPTION
## Summary

Replace the bright red keepout zone overlay with a subtle semi-transparent white to reduce visual noise while keeping zones clearly identifiable.

## Changes

- `src/lib/draw-pcb-keepout.ts`: Configure drawer color override for keepout zones from default red to `rgba(255, 255, 255, 0.25)`

## Test plan

- Verify keepout zones in the KeepoutRectExample and KeepoutCircleExample fixtures no longer show a thick red outline
- Confirm keepout zones are still visible with the subtle hatch pattern

Fixes #47