### PR TITLE
feat: deprecate disableAutoFocus in favor of focusOnHover={false}

### DIFF
--- a/src/PCBViewer.tsx
+++ b/src/PCBViewer.tsx
@@ -24,7 +24,16 @@ type Props = {
   editEvents?: ManualEditEvent[]
   initialState?: Partial<StateProps>
   onEditEventsChanged?: (editEvents: ManualEditEvent[]) => void
+  /**
+   * When true, the viewer will focus (grab keyboard events) when the mouse
+   * hovers over it. Defaults to false.
+   */
   focusOnHover?: boolean
+  /**
+   * @deprecated Use `focusOnHover={false}` instead. This prop will be removed
+   * in a future release.
+   */
+  disableAutoFocus?: boolean
   clickToInteractEnabled?: boolean
   debugGraphics?: GraphicsObject | null
   disablePcbGroups?: boolean
@@ -38,10 +47,18 @@ export const PCBViewer = ({
   allowEditing = true,
   editEvents: editEventsProp,
   onEditEventsChanged,
-  focusOnHover = false,
+  focusOnHover: focusOnHoverProp,
+  disableAutoFocus,
   clickToInteractEnabled = false,
   disablePcbGroups = false,
 }: Props) => {
+  // disableAutoFocus is a deprecated alias for !focusOnHover
+  const focusOnHover =
+    focusOnHoverProp !== undefined
+      ? focusOnHoverProp
+      : disableAutoFocus !== undefined
+        ? !disableAutoFocus
+        : false
   const [isInteractionEnabled, setIsInteractionEnabled] = useState(
     !clickToInteractEnabled,
   )


### PR DESCRIPTION
/claim #163

## Summary

`focusOnHover` is already implemented in main. This PR adds a deprecated `disableAutoFocus` prop that maps to `!focusOnHover` so existing code using the old prop continues to work while guiding users toward the new API.

## Changes

- Added `disableAutoFocus?: boolean` to `PCBViewer` Props with a `@deprecated` JSDoc comment
- `focusOnHoverProp` takes priority when both props are provided
- `disableAutoFocus={true}` maps to `focusOnHover = false` (no focus on hover)
- `disableAutoFocus={false}` maps to `focusOnHover = true` (focus on hover)
- Default behavior unchanged: `focusOnHover = false` when neither prop is passed

## Test plan

- [x] All 22 tests pass with `bun test`
- [x] `bun x tsc --noEmit` passes with no type errors
- [x] `biome format` reports no issues