### PR TITLE
Keep component anchor offset labels synced after move operations

### DIFF
--- a/src/components/AnchorOffsetOverlay/BoardAnchorOffsetOverlay.tsx
+++ b/src/components/AnchorOffsetOverlay/BoardAnchorOffsetOverlay.tsx
@@ -132,8 +132,6 @@ export const BoardAnchorOffsetOverlay = ({
           anchor_id: target.board.pcb_board_id,
           target: target.component.center as Point,
           type: "component",
-          display_offset_x: target.component.display_offset_x,
-          display_offset_y: target.component.display_offset_y,
         }
       }
       // group

--- a/src/components/AnchorOffsetOverlay/GroupAnchorOffsetOverlay.tsx
+++ b/src/components/AnchorOffsetOverlay/GroupAnchorOffsetOverlay.tsx
@@ -203,8 +203,6 @@ export const GroupAnchorOffsetOverlay = ({
           anchor_id: target.parentGroup.pcb_group_id,
           target: target.component.center,
           type: "component",
-          display_offset_x: target.component.display_offset_x,
-          display_offset_y: target.component.display_offset_y,
         }
       }
       // group - use anchor_position for anchor-to-anchor offsets


### PR DESCRIPTION
This PR fixes a component-move regression in pcb-viewer where the anchor offset labels could show stale display_offset_x / display_offset_y values after a component was dragged.

## Before

https://github.com/user-attachments/assets/204ad4c0-7466-4f8e-abed-cc8692955089


## After

https://github.com/user-attachments/assets/eb1b68e3-c6ad-4c83-8ec4-deedb9a8f806



  Changes:

  - make component anchor offset overlays use the component’s current computed position instead of falling back to persisted display offset labels
  - preserve existing behavior for non-component anchor overlays
  - keep the move-component X/Y feedback consistent during drag and after mouse release

  Why this matters:

  - fixes a subtle but important rendering/calculation bug in move-component UX
  - improves editor feedback by ensuring the displayed offsets match the actual component location
  - avoids misleading negative/old values after repositioning a component