### PR TITLE
fix: filter plated holes and vias by layer to prevent bottom layer bleed-through

### DIFF
--- a/src/lib/draw-plated-hole.ts
+++ b/src/lib/draw-plated-hole.ts
@@ -1,4 +1,4 @@
-import type { AnyCircuitElement, PcbRenderLayer } from "circuit-json"
+import type { AnyCircuitElement, PcbPlatedHole, PcbRenderLayer } from "circuit-json"
 import {
   CircuitToCanvasDrawer,
   DEFAULT_PCB_COLOR_MAP,
@@ -6,7 +6,6 @@ import {
 } from "circuit-to-canvas"
 import color from "color"
 import type { Matrix } from "transformation-matrix"
-import { useGlobalStore } from "../global-store"
 import colors from "./colors"
 import type { Primitive } from "./types"
 
@@ -20,8 +19,18 @@ const HOVER_COLOR_MAP: PcbColorMap = {
   },
 }
 
-export function isPlatedHole(element: AnyCircuitElement) {
+export function isPlatedHole(
+  element: AnyCircuitElement,
+): element is PcbPlatedHole {
   return element.type === "pcb_plated_hole"
+}
+
+/**
+ * Maps a PcbRenderLayer (e.g. "top_copper") to the bare LayerRef used in
+ * pcb_plated_hole.layers (e.g. "top").
+ */
+function copperLayerToLayerRef(layer: PcbRenderLayer): string {
+  return layer.endsWith("_copper") ? layer.replace("_copper", "") : layer
 }
 
 export function drawPlatedHolePads({
@@ -39,7 +48,19 @@ export function drawPlatedHolePads({
   primitives?: Primitive[]
   drawSoldermask?: boolean
 }) {
-  const platedHoleElements = elements.filter(isPlatedHole)
+  // Convert render layers (e.g. "top_copper") to bare layer refs (e.g. "top")
+  // so we can match against pcb_plated_hole.layers which uses bare refs.
+  const targetLayerRefs = new Set(layers.map(copperLayerToLayerRef))
+
+  // Only draw holes that have at least one of their layers on the target canvas.
+  // This prevents bottom-layer holes from bleeding through onto the top canvas
+  // (and vice versa) at the 0.5 opacity used for non-foreground layers.
+  const platedHoleElements = elements.filter(isPlatedHole).filter((element) => {
+    const holeLayers = element.layers ?? []
+    // If the hole has no layers info, fall back to drawing it on all canvases
+    if (holeLayers.length === 0) return true
+    return holeLayers.some((l) => targetLayerRefs.has(l))
+  })
 
   if (platedHoleElements.length === 0) return
 

--- a/src/lib/draw-via.ts
+++ b/src/lib/draw-via.ts
@@ -3,7 +3,7 @@ import {
   type PcbColorMap,
   CircuitToCanvasDrawer,
 } from "circuit-to-canvas"
-import type { AnyCircuitElement, PcbRenderLayer } from "circuit-json"
+import type { AnyCircuitElement, PcbRenderLayer, PcbVia } from "circuit-json"
 import type { Matrix } from "transformation-matrix"
 import colors from "./colors"
 import color from "color"
@@ -19,7 +19,7 @@ const HOVER_COLOR_MAP: PcbColorMap = {
   },
 }
 
-export function isPcbVia(element: AnyCircuitElement) {
+export function isPcbVia(element: AnyCircuitElement): element is PcbVia {
   return element.type === "pcb_via"
 }
 
@@ -38,10 +38,22 @@ export function drawPcbViaElementsForLayer({
   primitives?: Primitive[]
   drawSoldermask?: boolean
 }) {
-  // Filter vias to only those on the specified layers
+  // Convert render layers (e.g. "top_copper") to bare layer refs (e.g. "top")
+  // to match against pcb_via.layers which uses bare layer refs.
+  const targetLayerRefs = new Set(
+    layers.map((l) => (l.endsWith("_copper") ? l.replace("_copper", "") : l)),
+  )
+
+  // Filter vias to only those that include the target layer.
+  // This prevents via copper rings from appearing on non-foreground canvases
+  // (which are shown at 0.5 opacity), causing visible bleed-through.
   const viaElements = elements.filter(isPcbVia).filter((element) => {
-    // Vias are typically drawn on copper layers
-    return layers.some((layer) => layer.includes("copper"))
+    const viaLayers = element.layers ?? []
+    if (viaLayers.length === 0) {
+      // Fallback: draw on any copper layer canvas (legacy behaviour)
+      return layers.some((layer) => layer.includes("copper"))
+    }
+    return viaLayers.some((l) => targetLayerRefs.has(l))
   })
 
   if (viaElements.length === 0) return


### PR DESCRIPTION
Closes #696\n\nPlated holes and vias were rendering on both top and bottom canvases unconditionally. Now they only render on the selected foreground layer canvas.