### PR TITLE
feat(toolbar): add Show Top / Bottom Components toggles to View dropdown

### DIFF
--- a/src/components/CanvasPrimitiveRenderer.tsx
+++ b/src/components/CanvasPrimitiveRenderer.tsx
@@ -1,6 +1,7 @@
 import type { AnyCircuitElement, PcbRenderLayer } from "circuit-json"
 import { Drawer } from "lib/Drawer"
 import { drawCopperPourElementsForLayer } from "lib/draw-copper-pour"
+import { drawCourtyardElementsForLayer } from "lib/draw-courtyard"
 import { drawFabricationNoteElementsForLayer } from "lib/draw-fabrication-note"
 import { drawGrid } from "lib/draw-grid"
 import { drawPcbHoleElementsForLayer } from "lib/draw-hole"
@@ -14,12 +15,15 @@ import { drawPcbSmtPadElementsForLayer } from "lib/draw-pcb-smtpad"
 import { drawPcbTraceElementsForLayer } from "lib/draw-pcb-trace"
 import { drawPlatedHolePads } from "lib/draw-plated-hole"
 import { drawPrimitives } from "lib/draw-primitives"
-import { drawSoldermaskElementsForLayer } from "lib/draw-soldermask"
 import { drawSilkscreenElementsForLayer } from "lib/draw-silkscreen"
+import { drawSoldermaskElementsForLayer } from "lib/draw-soldermask"
 import { drawPcbViaElementsForLayer } from "lib/draw-via"
-import { drawCourtyardElementsForLayer } from "lib/draw-courtyard"
 import type { GridConfig, Primitive } from "lib/types"
-import React, { useEffect, useRef } from "react"
+import {
+  filterElementsByVisibility,
+  getHiddenPcbComponentIds,
+} from "lib/util/component-visibility"
+import React, { useEffect, useMemo, useRef } from "react"
 import { SuperGrid, toMMSI } from "react-supergrid"
 import type { Matrix } from "transformation-matrix"
 import { useGlobalStore } from "../global-store"
@@ -77,6 +81,30 @@ export const CanvasPrimitiveRenderer = ({
   )
   const isShowingCourtyards = useGlobalStore((s) => s.is_showing_courtyards)
   const isShowingSilkscreen = useGlobalStore((s) => s.is_showing_silkscreen)
+  const isShowingTopComponents = useGlobalStore(
+    (s) => s.is_showing_top_components,
+  )
+  const isShowingBottomComponents = useGlobalStore(
+    (s) => s.is_showing_bottom_components,
+  )
+
+  // Hide pcb_components whose layer is toggled off. Through-hole
+  // components (any pcb_component that owns at least one
+  // pcb_plated_hole) stay visible regardless — they exist on both
+  // sides of the board.
+  const hiddenPcbComponentIds = useMemo(
+    () =>
+      getHiddenPcbComponentIds(
+        elements,
+        isShowingTopComponents,
+        isShowingBottomComponents,
+      ),
+    [elements, isShowingTopComponents, isShowingBottomComponents],
+  )
+  const visibleElements = useMemo(
+    () => filterElementsByVisibility(elements, hiddenPcbComponentIds),
+    [elements, hiddenPcbComponentIds],
+  )
 
   useEffect(() => {
     if (!canvasRefs.current) return
@@ -111,6 +139,13 @@ export const CanvasPrimitiveRenderer = ({
       .filter((p) => p._element?.type !== "pcb_via")
       .filter((p) => p._element?.type !== "pcb_trace")
       .filter((p) => p._element?.type !== "pcb_copper_text")
+      .filter((p) => {
+        const parentId = (p as any)._parent_pcb_component?.pcb_component_id as
+          | string
+          | undefined
+        if (!parentId) return true
+        return !hiddenPcbComponentIds.has(parentId)
+      })
 
     drawPrimitives(drawer, filteredPrimitives)
 
@@ -155,7 +190,7 @@ export const CanvasPrimitiveRenderer = ({
         if (!canvas) continue
         drawPcbCopperTextElementsForLayer({
           canvas,
-          elements,
+          elements: visibleElements,
           layers: [copperLayer],
           realToCanvasMat: transform,
         })
@@ -199,7 +234,7 @@ export const CanvasPrimitiveRenderer = ({
         if (!canvas) continue
         drawPcbSmtPadElementsForLayer({
           canvas,
-          elements,
+          elements: visibleElements,
           layers: [copperLayer],
           realToCanvasMat: transform,
           primitives,
@@ -239,7 +274,7 @@ export const CanvasPrimitiveRenderer = ({
         if (topSoldermaskCanvas && soldermaskLayer === "top") {
           drawSoldermaskElementsForLayer({
             canvas: topSoldermaskCanvas,
-            elements,
+            elements: visibleElements,
             layers: ["top_soldermask"],
             realToCanvasMat: transform,
             drawSoldermaskTop,
@@ -252,7 +287,7 @@ export const CanvasPrimitiveRenderer = ({
         if (bottomSoldermaskCanvas && soldermaskLayer === "bottom") {
           drawSoldermaskElementsForLayer({
             canvas: bottomSoldermaskCanvas,
-            elements,
+            elements: visibleElements,
             layers: ["bottom_soldermask"],
             realToCanvasMat: transform,
             drawSoldermaskTop,
@@ -279,7 +314,7 @@ export const CanvasPrimitiveRenderer = ({
         if (topSilkscreenCanvas) {
           drawSilkscreenElementsForLayer({
             canvas: topSilkscreenCanvas,
-            elements,
+            elements: visibleElements,
             layers: ["top_silkscreen"],
             realToCanvasMat: transform,
           })
@@ -289,7 +324,7 @@ export const CanvasPrimitiveRenderer = ({
         if (bottomSilkscreenCanvas) {
           drawSilkscreenElementsForLayer({
             canvas: bottomSilkscreenCanvas,
-            elements,
+            elements: visibleElements,
             layers: ["bottom_silkscreen"],
             realToCanvasMat: transform,
           })
@@ -302,7 +337,7 @@ export const CanvasPrimitiveRenderer = ({
         if (topFabCanvas) {
           drawFabricationNoteElementsForLayer({
             canvas: topFabCanvas,
-            elements,
+            elements: visibleElements,
             layers: ["top_fabrication_note"],
             realToCanvasMat: transform,
           })
@@ -313,7 +348,7 @@ export const CanvasPrimitiveRenderer = ({
         if (bottomFabCanvas) {
           drawFabricationNoteElementsForLayer({
             canvas: bottomFabCanvas,
-            elements,
+            elements: visibleElements,
             layers: ["bottom_fabrication_note"],
             realToCanvasMat: transform,
           })
@@ -348,7 +383,7 @@ export const CanvasPrimitiveRenderer = ({
         if (topCourtyardCanvas) {
           drawCourtyardElementsForLayer({
             canvas: topCourtyardCanvas,
-            elements,
+            elements: visibleElements,
             layers: ["top_courtyard" as PcbRenderLayer],
             realToCanvasMat: transform,
           })
@@ -359,7 +394,7 @@ export const CanvasPrimitiveRenderer = ({
         if (bottomCourtyardCanvas) {
           drawCourtyardElementsForLayer({
             canvas: bottomCourtyardCanvas,
-            elements,
+            elements: visibleElements,
             layers: ["bottom_courtyard" as PcbRenderLayer],
             realToCanvasMat: transform,
           })
@@ -417,6 +452,8 @@ export const CanvasPrimitiveRenderer = ({
   }, [
     primitives,
     elements,
+    visibleElements,
+    hiddenPcbComponentIds,
     transform,
     selectedLayer,
     isShowingSolderMask,

--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -1,20 +1,20 @@
-import {
-  useEffect,
-  useState,
-  useCallback,
-  useRef,
-  useLayoutEffect,
-} from "react"
 import { css } from "@emotion/css"
-import { type LayerRef } from "circuit-json"
+import type { LayerRef } from "circuit-json"
 import type { AnyCircuitElement } from "circuit-json"
-import { LAYER_NAME_TO_COLOR } from "lib/Drawer"
-import { useGlobalStore } from "../global-store"
-import packageJson from "../../package.json"
 import { useHotKey } from "hooks/useHotKey"
-import { zIndexMap } from "lib/util/z-index-map"
 import { useIsSmallScreen } from "hooks/useIsSmallScreen"
 import { useMobileTouch } from "hooks/useMobileTouch"
+import { LAYER_NAME_TO_COLOR } from "lib/Drawer"
+import { zIndexMap } from "lib/util/z-index-map"
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react"
+import packageJson from "../../package.json"
+import { useGlobalStore } from "../global-store"
 import { ToolbarButton } from "./ToolbarButton"
 import { ToolbarErrorDropdown } from "./ToolbarErrorDropdown"
 
@@ -155,6 +155,8 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     setIsShowingSolderMask,
     setIsShowingSilkscreen,
     setIsShowingFabricationNotes,
+    setIsShowingTopComponents,
+    setIsShowingBottomComponents,
     setPcbGroupViewMode,
     setHoveredErrorId,
     setFocusedErrorId,
@@ -179,6 +181,8 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
       is_showing_solder_mask: s.is_showing_solder_mask,
       is_showing_silkscreen: s.is_showing_silkscreen,
       is_showing_fabrication_notes: s.is_showing_fabrication_notes,
+      is_showing_top_components: s.is_showing_top_components,
+      is_showing_bottom_components: s.is_showing_bottom_components,
       pcb_group_view_mode: s.pcb_group_view_mode,
     },
     setEditMode: s.setEditMode,
@@ -193,6 +197,8 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     setIsShowingSolderMask: s.setIsShowingSolderMask,
     setIsShowingSilkscreen: s.setIsShowingSilkscreen,
     setIsShowingFabricationNotes: s.setIsShowingFabricationNotes,
+    setIsShowingTopComponents: s.setIsShowingTopComponents,
+    setIsShowingBottomComponents: s.setIsShowingBottomComponents,
     setPcbGroupViewMode: s.setPcbGroupViewMode,
     setHoveredErrorId: s.setHoveredErrorId,
     setFocusedErrorId: s.setFocusedErrorId,
@@ -587,6 +593,24 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
                   checked={viewSettings.is_showing_silkscreen}
                   onClick={() => {
                     setIsShowingSilkscreen(!viewSettings.is_showing_silkscreen)
+                  }}
+                />
+                <CheckboxMenuItem
+                  label="Show Top Components"
+                  checked={viewSettings.is_showing_top_components}
+                  onClick={() => {
+                    setIsShowingTopComponents(
+                      !viewSettings.is_showing_top_components,
+                    )
+                  }}
+                />
+                <CheckboxMenuItem
+                  label="Show Bottom Components"
+                  checked={viewSettings.is_showing_bottom_components}
+                  onClick={() => {
+                    setIsShowingBottomComponents(
+                      !viewSettings.is_showing_bottom_components,
+                    )
                   }}
                 />
                 <CheckboxMenuItem

--- a/src/global-store.ts
+++ b/src/global-store.ts
@@ -1,16 +1,16 @@
+import type { LayerRef } from "circuit-json"
+import { useContext } from "react"
 import {
   createStore as createZustandStore,
   useStore as useZustandStore,
 } from "zustand"
 import { StoreContext } from "./components/ContextProviders"
-import type { LayerRef } from "circuit-json"
-import { useContext } from "react"
 import {
+  STORAGE_KEYS,
   getStoredBoolean,
   getStoredString,
   setStoredBoolean,
   setStoredString,
-  STORAGE_KEYS,
 } from "./hooks/useLocalStorage"
 
 export interface State {
@@ -36,6 +36,8 @@ export interface State {
   is_showing_solder_mask: boolean
   is_showing_silkscreen: boolean
   is_showing_fabrication_notes: boolean
+  is_showing_top_components: boolean
+  is_showing_bottom_components: boolean
   pcb_group_view_mode: "all" | "named_only"
 
   hovered_error_id: string | null
@@ -57,6 +59,8 @@ export interface State {
   setIsShowingSolderMask: (is_showing: boolean) => void
   setIsShowingSilkscreen: (is_showing: boolean) => void
   setIsShowingFabricationNotes: (is_showing: boolean) => void
+  setIsShowingTopComponents: (is_showing: boolean) => void
+  setIsShowingBottomComponents: (is_showing: boolean) => void
   setPcbGroupViewMode: (mode: "all" | "named_only") => void
   setHoveredErrorId: (errorId: string | null) => void
   setFocusedErrorId: (errorId: string | null) => void
@@ -118,6 +122,14 @@ export const createStore = (
         is_showing_fabrication_notes: getStoredBoolean(
           STORAGE_KEYS.IS_SHOWING_FABRICATION_NOTES,
           false,
+        ),
+        is_showing_top_components: getStoredBoolean(
+          STORAGE_KEYS.IS_SHOWING_TOP_COMPONENTS,
+          true,
+        ),
+        is_showing_bottom_components: getStoredBoolean(
+          STORAGE_KEYS.IS_SHOWING_BOTTOM_COMPONENTS,
+          true,
         ),
         pcb_group_view_mode: disablePcbGroups
           ? "all"
@@ -187,6 +199,17 @@ export const createStore = (
             is_showing,
           )
           set({ is_showing_fabrication_notes: is_showing })
+        },
+        setIsShowingTopComponents: (is_showing) => {
+          setStoredBoolean(STORAGE_KEYS.IS_SHOWING_TOP_COMPONENTS, is_showing)
+          set({ is_showing_top_components: is_showing })
+        },
+        setIsShowingBottomComponents: (is_showing) => {
+          setStoredBoolean(
+            STORAGE_KEYS.IS_SHOWING_BOTTOM_COMPONENTS,
+            is_showing,
+          )
+          set({ is_showing_bottom_components: is_showing })
         },
         setPcbGroupViewMode: (mode) => {
           if (disablePcbGroups) return

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -9,6 +9,8 @@ export const STORAGE_KEYS = {
   IS_SHOWING_SOLDER_MASK: "pcb_viewer_is_showing_solder_mask",
   IS_SHOWING_FABRICATION_NOTES: "pcb_viewer_is_showing_fabrication_notes",
   IS_SHOWING_SILKSCREEN: "pcb_viewer_is_showing_silkscreen",
+  IS_SHOWING_TOP_COMPONENTS: "pcb_viewer_is_showing_top_components",
+  IS_SHOWING_BOTTOM_COMPONENTS: "pcb_viewer_is_showing_bottom_components",
 } as const
 
 export const getStoredBoolean = (

--- a/src/lib/util/component-visibility.ts
+++ b/src/lib/util/component-visibility.ts
@@ -1,0 +1,67 @@
+import type { AnyCircuitElement } from "circuit-json"
+
+export type ComponentKind = "through_hole" | "smt_top" | "smt_bottom"
+
+// Classify each pcb_component as either through_hole (has at least one
+// pcb_plated_hole) or smt on its declared layer. Through-hole components
+// stay visible regardless of the top/bottom toggles.
+export const classifyPcbComponents = (
+  elements: AnyCircuitElement[],
+): Map<string, ComponentKind> => {
+  const kindById = new Map<string, ComponentKind>()
+  const platedHoleComponentIds = new Set<string>()
+
+  for (const el of elements) {
+    if (el.type !== "pcb_plated_hole") continue
+    const id = (el as any).pcb_component_id as string | undefined
+    if (id) platedHoleComponentIds.add(id)
+  }
+
+  for (const el of elements) {
+    if (el.type !== "pcb_component") continue
+    const id = (el as any).pcb_component_id as string
+    if (platedHoleComponentIds.has(id)) {
+      kindById.set(id, "through_hole")
+      continue
+    }
+    const layer = (el as any).layer
+    kindById.set(id, layer === "bottom" ? "smt_bottom" : "smt_top")
+  }
+
+  return kindById
+}
+
+// Returns the set of pcb_component_ids that should NOT be drawn given
+// the top/bottom toggle state. Through-hole components are always kept
+// visible (they exist on both sides).
+export const getHiddenPcbComponentIds = (
+  elements: AnyCircuitElement[],
+  isShowingTopComponents: boolean,
+  isShowingBottomComponents: boolean,
+): Set<string> => {
+  const hidden = new Set<string>()
+  if (isShowingTopComponents && isShowingBottomComponents) return hidden
+
+  const kindById = classifyPcbComponents(elements)
+  for (const [id, kind] of kindById) {
+    if (kind === "smt_top" && !isShowingTopComponents) hidden.add(id)
+    if (kind === "smt_bottom" && !isShowingBottomComponents) hidden.add(id)
+  }
+  return hidden
+}
+
+// Returns a filtered view of `elements` with everything tied to a hidden
+// pcb_component_id removed. Elements without a `pcb_component_id` (board
+// outline, edge cuts, vias, traces, copper pours, ...) are passed
+// through unchanged.
+export const filterElementsByVisibility = (
+  elements: AnyCircuitElement[],
+  hiddenPcbComponentIds: Set<string>,
+): AnyCircuitElement[] => {
+  if (hiddenPcbComponentIds.size === 0) return elements
+  return elements.filter((el) => {
+    const id = (el as any).pcb_component_id as string | undefined
+    if (!id) return true
+    return !hiddenPcbComponentIds.has(id)
+  })
+}

--- a/tests/lib/component-visibility.test.ts
+++ b/tests/lib/component-visibility.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import {
+  classifyPcbComponents,
+  filterElementsByVisibility,
+  getHiddenPcbComponentIds,
+} from "../../src/lib/util/component-visibility"
+
+const mkPcbComponent = (id: string, layer: "top" | "bottom") =>
+  ({
+    type: "pcb_component",
+    pcb_component_id: id,
+    source_component_id: `src_${id}`,
+    center: { x: 0, y: 0 },
+    width: 1,
+    height: 1,
+    layer,
+    rotation: 0,
+  }) as unknown as AnyCircuitElement
+
+const mkSmtPad = (id: string, parent: string, layer: "top" | "bottom") =>
+  ({
+    type: "pcb_smtpad",
+    pcb_smtpad_id: id,
+    pcb_component_id: parent,
+    shape: "rect",
+    x: 0,
+    y: 0,
+    width: 1,
+    height: 1,
+    layer,
+  }) as unknown as AnyCircuitElement
+
+const mkPlatedHole = (id: string, parent: string) =>
+  ({
+    type: "pcb_plated_hole",
+    pcb_plated_hole_id: id,
+    pcb_component_id: parent,
+    shape: "circle",
+    x: 0,
+    y: 0,
+    hole_diameter: 0.6,
+    outer_diameter: 1.0,
+  }) as unknown as AnyCircuitElement
+
+const mkBoard = () =>
+  ({
+    type: "pcb_board",
+    pcb_board_id: "board0",
+    center: { x: 0, y: 0 },
+    width: 50,
+    height: 14,
+    num_layers: 2,
+  }) as unknown as AnyCircuitElement
+
+describe("classifyPcbComponents", () => {
+  it("classifies a top-side SMT chip as smt_top", () => {
+    const elements = [mkPcbComponent("c1", "top"), mkSmtPad("p1", "c1", "top")]
+    const kindById = classifyPcbComponents(elements)
+    expect(kindById.get("c1")).toBe("smt_top")
+  })
+
+  it("classifies a bottom-side SMT chip as smt_bottom", () => {
+    const elements = [
+      mkPcbComponent("c1", "bottom"),
+      mkSmtPad("p1", "c1", "bottom"),
+    ]
+    const kindById = classifyPcbComponents(elements)
+    expect(kindById.get("c1")).toBe("smt_bottom")
+  })
+
+  it("classifies a connector with a plated hole as through_hole", () => {
+    const elements = [mkPcbComponent("c1", "top"), mkPlatedHole("ph1", "c1")]
+    const kindById = classifyPcbComponents(elements)
+    expect(kindById.get("c1")).toBe("through_hole")
+  })
+
+  it("classifies a chip with both SMT pads and a plated hole as through_hole", () => {
+    const elements = [
+      mkPcbComponent("c1", "top"),
+      mkSmtPad("p1", "c1", "top"),
+      mkPlatedHole("ph1", "c1"),
+    ]
+    expect(classifyPcbComponents(elements).get("c1")).toBe("through_hole")
+  })
+})
+
+describe("getHiddenPcbComponentIds", () => {
+  const mixedBoard: AnyCircuitElement[] = [
+    mkBoard(),
+    mkPcbComponent("top1", "top"),
+    mkSmtPad("p_top1", "top1", "top"),
+    mkPcbComponent("top2", "top"),
+    mkSmtPad("p_top2", "top2", "top"),
+    mkPcbComponent("bot1", "bottom"),
+    mkSmtPad("p_bot1", "bot1", "bottom"),
+    mkPcbComponent("conn1", "top"),
+    mkPlatedHole("ph_conn1", "conn1"),
+  ]
+
+  it("returns an empty set when both layers are visible", () => {
+    expect(getHiddenPcbComponentIds(mixedBoard, true, true).size).toBe(0)
+  })
+
+  it("hides only top SMT components when top is toggled off", () => {
+    const hidden = getHiddenPcbComponentIds(mixedBoard, false, true)
+    expect(hidden.has("top1")).toBe(true)
+    expect(hidden.has("top2")).toBe(true)
+    expect(hidden.has("bot1")).toBe(false)
+    expect(hidden.has("conn1")).toBe(false) // through-hole stays visible
+  })
+
+  it("hides only bottom SMT components when bottom is toggled off", () => {
+    const hidden = getHiddenPcbComponentIds(mixedBoard, true, false)
+    expect(hidden.has("top1")).toBe(false)
+    expect(hidden.has("bot1")).toBe(true)
+    expect(hidden.has("conn1")).toBe(false)
+  })
+
+  it("keeps through-hole components visible even when both SMT layers are off", () => {
+    const hidden = getHiddenPcbComponentIds(mixedBoard, false, false)
+    expect(hidden.has("top1")).toBe(true)
+    expect(hidden.has("top2")).toBe(true)
+    expect(hidden.has("bot1")).toBe(true)
+    expect(hidden.has("conn1")).toBe(false)
+  })
+})
+
+describe("filterElementsByVisibility", () => {
+  const board: AnyCircuitElement[] = [
+    mkBoard(),
+    mkPcbComponent("top1", "top"),
+    mkSmtPad("p_top1", "top1", "top"),
+    mkPcbComponent("conn1", "top"),
+    mkPlatedHole("ph_conn1", "conn1"),
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "t1",
+      route: [],
+    } as unknown as AnyCircuitElement,
+  ]
+
+  it("returns the original array when nothing is hidden", () => {
+    const out = filterElementsByVisibility(board, new Set())
+    expect(out).toBe(board)
+  })
+
+  it("drops elements whose pcb_component_id is hidden, keeps board/trace untouched", () => {
+    const out = filterElementsByVisibility(board, new Set(["top1"]))
+    expect(
+      out.find((e) => (e as any).pcb_component_id === "top1"),
+    ).toBeUndefined()
+    expect(
+      out.find((e) => (e as any).pcb_smtpad_id === "p_top1"),
+    ).toBeUndefined()
+    expect(out.find((e) => e.type === "pcb_board")).toBeDefined()
+    expect(out.find((e) => e.type === "pcb_trace")).toBeDefined()
+    expect(
+      out.find((e) => (e as any).pcb_component_id === "conn1"),
+    ).toBeDefined()
+    expect(
+      out.find((e) => (e as any).pcb_plated_hole_id === "ph_conn1"),
+    ).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

Closes #755.

Adds two new checkboxes to the View ▼ dropdown:

- **Show Top Components** (default on)
- **Show Bottom Components** (default on)

…that hide every SMT component on the corresponding side of the board, while keeping through-hole components (any `pcb_component` that owns at least one `pcb_plated_hole`) visible regardless. The selected `layer:` dropdown (top / bottom highlight) is untouched — these toggles are about visibility, not foreground/background.

Defaults to true / true; persisted to `localStorage` like the rest of the view toggles.

## Why through-holes are special

A connector with two PTH pads (e.g. a JST-PH on one edge of the board) physically exists on both sides — it has copper on top and bottom, with the through-hole drilled across. Hiding it on one toggle would leave the wrong side rendering its pad outline. Easier and more useful to classify any `pcb_component` that owns at least one `pcb_plated_hole` as "through-hole" and never hide it.

## Implementation

One helper file does the classification:

```ts
// src/lib/util/component-visibility.ts
export type ComponentKind = "through_hole" | "smt_top" | "smt_bottom"
export const classifyPcbComponents(elements): Map<id, kind>
export const getHiddenPcbComponentIds(elements, showTop, showBottom): Set<id>
export const filterElementsByVisibility(elements, hiddenIds): elements
```

`CanvasPrimitiveRenderer` calls `getHiddenPcbComponentIds` once per render (memoized on `[elements, showTop, showBottom]`), then:

1. Filters `primitives` to drop any whose `_parent_pcb_component.pcb_component_id` is in the hidden set.
2. Builds a `visibleElements` view of `elements` with hidden-component-tied elements removed and passes it to the per-component canvas drawers (`drawPcbSmtPadElementsForLayer`, `drawSilkscreenElementsForLayer`, `drawFabricationNoteElementsForLayer`, `drawCourtyardElementsForLayer`, `drawSoldermaskElementsForLayer`, `drawPcbCopperTextElementsForLayer`).
3. Leaves the unfiltered `elements` going to drawers that aren't component-tied: board outline, edge cuts, copper pours, vias, traces, plated holes, hole drills, board notes.

Because `filterElementsByVisibility` is a pass-through for any element without `pcb_component_id`, the only thing actually dropped is per-component artwork. Nothing referenced by a hidden component's `source_component_id` is touched (those are schematic-side and don't reach this canvas).

## Store changes

Added to `global-store.ts`:

```ts
is_showing_top_components: boolean
is_showing_bottom_components: boolean
setIsShowingTopComponents: (b: boolean) => void
setIsShowingBottomComponents: (b: boolean) => void
```

Plus the corresponding two `STORAGE_KEYS` entries in `useLocalStorage.ts`.

## Tests

`tests/lib/component-visibility.test.ts` — 10 tests covering:

- `classifyPcbComponents`: top SMT, bottom SMT, plated-hole-only connector, mixed (SMT + plated hole) — through_hole wins.
- `getHiddenPcbComponentIds`: both on, top off, bottom off, both off (through-holes always survive).
- `filterElementsByVisibility`: identity when nothing hidden; drops hidden-component-tied elements; passes board / trace / through-hole-component elements through.

All pass:

```
$ bun test tests/lib/component-visibility.test.ts
10 pass / 0 fail / 23 expect() calls
```

Existing test suite is unaffected.

## Manual test

Built locally and ran against a 50×14 mm 2-layer board with ~28 small SMTs, 6 SOT-23 MOSFETs split across both sides, plus 27 plated through-holes for connectors / test points / battery / motor.

- Both toggles on (default): identical to upstream.
- Top off: every top-side passive disappears; through-hole connectors stay; bottom-side population still rendered as expected.
- Bottom off: mirror image — bottom side empties; through-holes stay.
- Both off: only through-holes, traces, vias, copper pours, board outline.
- Toggle persists across full page reload via `localStorage`.

## Test plan

- [x] Unit tests pass locally
- [x] Visual sanity-check on a real 2-side board
- [ ] CI green
- [ ] Reviewer: confirm the through-hole-stays-visible rule matches the project's intent (alternative would be to also gate through-holes by `pcb_component.layer`, but that loses the "always visible" property which I think is more useful)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
