### PR TITLE
Rename disabled autofocus fixture

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- remove the remaining `DisabledAutoFocus` fixture name from examples
- rename it to `FocusOnHoverDisabled`
- make `focusOnHover={false}` explicit in the fixture

/claim #163

## Verification
- `rg -n "disableAutoFocus|DisabledAutoFocus" src README.md tests` (no matches)
- `bunx biome check src/examples/2025/board.fixture.tsx`
- `bun run build`
- `git diff --check`
