### PR TITLE
docs: prefer focusOnHover naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The PCBViewer component accepts these props:
 - `editEvents`: Array of edit events to apply
 - `onEditEventsChanged`: Callback when edit events change
 - `initialState`: Initial state for the viewer
+- `focusOnHover`: Focus the viewer when the cursor enters it (default: false)
 
 ### Features
 

--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
Fixes #163.

## Summary
- Rename the remaining DisabledAutoFocus fixture to FocusOnHoverDisabled.
- Pass focusOnHover={false} explicitly in that fixture.
- Document focusOnHover in the README props list.

## Verification
- npm install --no-package-lock --legacy-peer-deps
- npm run build
- npx tsc --noEmit
- npx biome format src/examples/2025/board.fixture.tsx
- git grep -n -i 'disableAutoFocus\\|DisabledAutoFocus' -- . ':!node_modules' ':!dist' returned no matches

Note: npm run format:check still reports existing repository-wide CRLF formatting differences across many unrelated files, so I kept formatting scoped to the touched fixture.