### PR TITLE
fix: replace DisabledAutoFocus with focusOnHover={false}

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }
@@ -131,4 +131,5 @@ export default {
   TriangleBoard,
   OctagonBoard,
   AtariBoard,
+  FocusOnHoverDisabled,
 }


### PR DESCRIPTION
Fixes #163

The `DisabledAutoFocus` export in `board.fixture.tsx` was using the legacy naming convention and didn't explicitly pass `focusOnHover={false}` to `PCBViewer`.

This PR:
- Renames `DisabledAutoFocus` to `FocusOnHoverDisabled` to match the current prop naming
- Explicitly passes `focusOnHover={false}` to make the behavior clear
- Adds `FocusOnHoverDisabled` to `export default` so it appears as a proper story

/claim #163