### PR TITLE
Fix missing hover color for traces

### DIFF
--- a/src/lib/draw-pcb-trace.ts
+++ b/src/lib/draw-pcb-trace.ts
@@ -14,8 +14,8 @@ const HOVER_COLOR_MAP: PcbColorMap = {
   ...DEFAULT_PCB_COLOR_MAP,
   copper: {
     ...DEFAULT_PCB_COLOR_MAP.copper,
-    top: color(colors.board.pad_front).lighten(0.5).toString(),
-    bottom: color(colors.board.pad_back).lighten(0.5).toString(),
+    top: color(colors.board.copper.f).lighten(0.5).toString(),
+    bottom: color(colors.board.copper.b).lighten(0.5).toString(),
     inner1: color(colors.board.copper.in1).lighten(0.5).toString(),
     inner2: color(colors.board.copper.in2).lighten(0.5).toString(),
     inner3: color(colors.board.copper.in3).lighten(0.5).toString(),


### PR DESCRIPTION
This PR fixes the issue where traces did not change color on hover. The issue was caused by using pad colors instead of copper colors in the HOVER_COLOR_MAP for the top and bottom layers.

Changes:
- Updated HOVER_COLOR_MAP in draw-pcb-trace.ts to use colors.board.copper.f and colors.board.copper.b

/claim #1130