### PR TITLE
Rename legacy DisabledAutoFocus fixture to focusOnHover naming

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- rename the remaining `DisabledAutoFocus` fixture export to `FocusOnHoverDisabled`
- make the fixture explicit by passing `focusOnHover={false}` to `PCBViewer`

This removes the remaining legacy `disableAutoFocus` naming surface in examples and aligns the fixture with the current prop model.

/claim #163