### PR TITLE
Replace DisabledAutoFocus example with focusOnHover={false}

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ The PCBViewer component accepts these props:
 - `editEvents`: Array of edit events to apply
 - `onEditEventsChanged`: Callback when edit events change
 - `initialState`: Initial state for the viewer
+- `focusOnHover`: When `true`, the viewer container receives focus on mouse enter so keyboard shortcuts work without clicking first (default: `false`)
+- `clickToInteractEnabled`: When `true`, user must click or tap once before pan/zoom (default: `false`)
+- `debugGraphics`: Optional debug overlay payload
+- `disablePcbGroups`: When `true`, PCB group UI is hidden in initial state
 
 ### Features
 

--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const BoardWithoutHoverFocus = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }
@@ -131,4 +131,5 @@ export default {
   TriangleBoard,
   OctagonBoard,
   AtariBoard,
+  BoardWithoutHoverFocus,
 }


### PR DESCRIPTION
Fixes #163

- Rename the board example from `DisabledAutoFocus` to `BoardWithoutHoverFocus` and pass `focusOnHover={false}` explicitly.
- Register the example in the fixture default export.
- Document `focusOnHover` and related props in the README.

/claim #163