### PR TITLE
Fix: missing trace hover highlighting for vias, SMT pads and plated holes

### DIFF
--- a/src/components/CanvasElementsRenderer.tsx
+++ b/src/components/CanvasElementsRenderer.tsx
@@ -182,16 +182,30 @@ export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
       const primitiveIdsInMousedOverNet: string[] = []
       for (const primitive of primitivesHoveredOver) {
         if (primitive._element) {
-          const connectedPrimitivesList = connectivityMap.getNetConnectedToId(
-            "pcb_port_id" in primitive._element
-              ? primitive._element?.pcb_port_id!
-              : "pcb_trace_id" in primitive._element
-                ? primitive._element?.pcb_trace_id!
-                : "",
-          )
-          primitiveIdsInMousedOverNet.push(
-            ...connectivityMap.getIdsConnectedToNet(connectedPrimitivesList!),
-          )
+          let id = ""
+          if ("pcb_port_id" in primitive._element) {
+            id = primitive._element.pcb_port_id!
+          } else if ("pcb_trace_id" in primitive._element) {
+            id = primitive._element.pcb_trace_id!
+          } else if ("pcb_via_id" in primitive._element) {
+            id = primitive._element.pcb_via_id!
+          } else if ("pcb_smtpad_id" in primitive._element) {
+            id = primitive._element.pcb_smtpad_id!
+          } else if ("pcb_plated_hole_id" in primitive._element) {
+            id = primitive._element.pcb_plated_hole_id!
+          }
+
+          if (id) {
+            const connectedPrimitivesList =
+              connectivityMap.getNetConnectedToId(id)
+            if (connectedPrimitivesList) {
+              primitiveIdsInMousedOverNet.push(
+                ...connectivityMap.getIdsConnectedToNet(
+                  connectedPrimitivesList!,
+                ),
+              )
+            }
+          }
         }
       }
 

--- a/src/lib/util/addInteractionMetadataToPrimitives.ts
+++ b/src/lib/util/addInteractionMetadataToPrimitives.ts
@@ -17,34 +17,45 @@ export function addInteractionMetadataToPrimitives({
     if (primitive?.layer === "drill") {
       newPrimitive.is_in_highlighted_net = false
       newPrimitive.is_mouse_over = false
-    } else if (
-      drawingObjectIdsWithMouseOver.has(primitive._pcb_drawing_object_id)
-    ) {
-      newPrimitive.is_mouse_over = true
-    } else if (
-      primitiveElement &&
-      (("pcb_trace_id" in primitiveElement &&
-        primitiveIdsInMousedOverNet.includes(primitiveElement.pcb_trace_id!)) ||
-        ("pcb_port_id" in primitiveElement &&
-          primitiveIdsInMousedOverNet.includes(
-            primitiveElement.pcb_port_id!,
-          )) ||
-        ("pcb_via_id" in primitiveElement &&
-          primitiveIdsInMousedOverNet.includes(primitiveElement.pcb_via_id!)) ||
-        ("pcb_component_id" in primitiveElement &&
-          primitiveIdsInMousedOverNet.includes(
-            primitiveElement.pcb_component_id!,
-          )) ||
-        (parentComponent &&
-          "pcb_component_id" in parentComponent &&
-          primitiveIdsInMousedOverNet.includes(
-            parentComponent.pcb_component_id!,
-          )))
-    ) {
-      newPrimitive.is_in_highlighted_net = true
     } else {
-      newPrimitive.is_in_highlighted_net = false
-      newPrimitive.is_mouse_over = false
+      if (drawingObjectIdsWithMouseOver.has(primitive._pcb_drawing_object_id)) {
+        newPrimitive.is_mouse_over = true
+      } else {
+        newPrimitive.is_mouse_over = false
+      }
+
+      if (
+        primitiveElement &&
+        (("pcb_trace_id" in primitiveElement &&
+          primitiveIdsInMousedOverNet.includes(primitiveElement.pcb_trace_id!)) ||
+          ("pcb_port_id" in primitiveElement &&
+            primitiveIdsInMousedOverNet.includes(
+              primitiveElement.pcb_port_id!,
+            )) ||
+          ("pcb_via_id" in primitiveElement &&
+            primitiveIdsInMousedOverNet.includes(primitiveElement.pcb_via_id!)) ||
+          ("pcb_component_id" in primitiveElement &&
+            primitiveIdsInMousedOverNet.includes(
+              primitiveElement.pcb_component_id!,
+            )) ||
+          ("pcb_plated_hole_id" in primitiveElement &&
+            primitiveIdsInMousedOverNet.includes(
+              primitiveElement.pcb_plated_hole_id!,
+            )) ||
+          ("pcb_smtpad_id" in primitiveElement &&
+            primitiveIdsInMousedOverNet.includes(
+              primitiveElement.pcb_smtpad_id!,
+            )) ||
+          (parentComponent &&
+            "pcb_component_id" in parentComponent &&
+            primitiveIdsInMousedOverNet.includes(
+              parentComponent.pcb_component_id!,
+            )))
+      ) {
+        newPrimitive.is_in_highlighted_net = true
+      } else {
+        newPrimitive.is_in_highlighted_net = false
+      }
     }
     newPrimitives.push(newPrimitive)
   }


### PR DESCRIPTION
This PR fixes an issue where hovering over vias, SMT pads, or plated holes did not highlight the connected traces in the same net. It also ensures that the hovered element itself is marked as being in the highlighted net for consistency.