### PR TITLE
fix(examples): rename DisabledAutoFocus fixture to use focusOnHover={false}

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
/claim #163

Closes #163.

## Summary

The `DisabledAutoFocus` fixture in `src/examples/2025/board.fixture.tsx` is the only remaining reference in the repo to the legacy `disableAutoFocus` API.

## Changes

- Renames the fixture export `DisabledAutoFocus` → `FocusOnHoverDisabled` to match the current `focusOnHover` API surface (consistent with sibling fixtures in `hover-behavior.fixture.tsx`).
- Adds `focusOnHover={false}` prop to `<PCBViewer />` so the fixture actually exercises the disabled-focus behavior its name implies (previously the prop was missing entirely, which meant it relied on default behavior).

## Verification

```
$ grep -rn "DisabledAutoFocus\|disableAutoFocus" --include="*.tsx" --include="*.ts" .
# (no matches after this PR)
```

Diff is 2 lines.
