### PR TITLE
Rename disabled autofocus fixture to focusOnHover

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
/claim #163

This removes the last legacy DisabledAutoFocus fixture name from the board examples and makes the replacement behavior explicit with focusOnHover={false}.

Checked:
- Branch diff is only the fixture rename and the focusOnHover prop.
- Confirmed the old fixture name is gone from the changed file.
