### PR TITLE
Fix #163: rename disabled autofocus fixture

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Renames the remaining legacy `DisabledAutoFocus` fixture to `FocusOnHoverDisabled`.
- Makes the fixture behavior explicit with `focusOnHover={false}`.
- Leaves the runtime API untouched because it already uses `focusOnHover`.

## Validation
- `bun install`
- `bunx biome check src/examples/2025/board.fixture.tsx`
- `bun run build`
- `git diff --check`

/claim #163