### PR TITLE
Remove stale disabled autofocus fixture

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,20 +112,6 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
-  const circuit = new Circuit()
-
-  circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
-
-  const soup = circuit.getCircuitJson()
-
-  return (
-    <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
-    </div>
-  )
-}
-
 export default {
   BasicRectangleBoard,
   TriangleBoard,


### PR DESCRIPTION
Removed the `DisabledAutoFocus` fixture since it was named after an old prop and now just duplicates the basic board example. The actual `focusOnHover={false}` behavior is already covered in `hover-behavior.fixture.tsx`, so this fixture was just stale code.

Closes #163
/claim #163