### PR TITLE
fix: rename disabled autofocus fixture

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
Fixes #163
/claim #163

## Summary
- Renames the remaining legacy `DisabledAutoFocus` fixture export to `FocusOnHoverDisabled`.
- Makes the example explicitly pass `focusOnHover={false}`.

## Validation
- `rg -n "disableAutoFocus|DisabledAutoFocus" src README.md tests` -> no matches
- `bunx biome check src/examples/2025/board.fixture.tsx`
- `bun run build`
- `git diff --check`