### PR TITLE
Update autofocus fixture to use focusOnHover

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
Fixes tscircuit/pcb-viewer#163

/claim #163

Summary:
- Renamed the remaining `DisabledAutoFocus` board fixture to `FocusOnHoverDisabled`
- Made the example explicitly pass `focusOnHover={false}`

Verification:
- `rg -n "disableAutoFocus|DisabledAutoFocus|FocusOnHoverDisabled|focusOnHover=\{false\}" src README.md tests`
- `git diff --check`