### PR TITLE
fix: remove legacy DisabledAutoFocus fixture in favor of focusOnHover prop

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -111,21 +111,6 @@ export const AtariBoard = () => {
     </div>
   )
 }
-
-export const DisabledAutoFocus = () => {
-  const circuit = new Circuit()
-
-  circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
-
-  const soup = circuit.getCircuitJson()
-
-  return (
-    <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
-    </div>
-  )
-}
-
 export default {
   BasicRectangleBoard,
   TriangleBoard,


### PR DESCRIPTION
/claim #163

Closes #163

## Summary
- Removed the legacy `DisabledAutoFocus` fixture from `board.fixture.tsx`
- This fixture was the last remaining reference to the deprecated `disableAutoFocus` naming
- It was functionally identical to `BasicRectangleBoard` since `focusOnHover` defaults to `false`
- The `hover-behavior.fixture.tsx` already provides proper `focusOnHover` usage examples

## Changes
- `src/examples/2025/board.fixture.tsx`: Removed `DisabledAutoFocus` fixture (15 lines)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>