### PR TITLE
refactor: drop disableAutoFocus naming in favor of focusOnHover

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
Closes #163

The `disableAutoFocus` prop has already been replaced by `focusOnHover` throughout the component code (`PCBViewer`, `CanvasElementsRenderer`, `DimensionOverlay`). The only remaining trace of the old `disableAutoFocus` naming was the `DisabledAutoFocus` board fixture.

This PR:
- Renames the `DisabledAutoFocus` fixture to `FocusOnHoverDisabled`.
- Makes it explicitly pass `focusOnHover={false}`, so the fixture actually exercises the prop instead of relying on the implicit default.

/claim #163