### PR TITLE
Use focusOnHover fixture naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ The PCBViewer component accepts these props:
 - `onEditEventsChanged`: Callback when edit events change
 - `onBoundsSelected`: Callback when the Bounds tool completes a rectangle selection. Receives `{ minX, minY, maxX, maxY }`.
 - `initialState`: Initial state for the viewer
+- `focusOnHover`: Focus the viewer when the pointer hovers it. Set `focusOnHover={false}` to keep hover focus disabled.
 
 ### Features
 

--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- rename the remaining legacy `DisabledAutoFocus` fixture to `FocusOnHoverDisabled`
- make the fixture explicitly pass `focusOnHover={false}`
- document the `focusOnHover` prop in the README props list

/claim #163

## Verification
- npx --yes bun x biome check src/examples/2025/board.fixture.tsx README.md
- npx --yes bun run build
- git diff --check
- rg -n "disableAutoFocus|DisabledAutoFocus" . -S # no matches