### PR TITLE
Rename focus-on-hover disabled fixture

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
Closes #163

/claim #163

## Changes
- Renames the stale `DisabledAutoFocus` fixture export to `FocusOnHoverDisabled`.
- Passes `focusOnHover={false}` explicitly in that fixture so the example uses the current prop name.

## Validation
- `./node_modules/.bin/biome format src/examples/2025/board.fixture.tsx`
- `npm run build`
- `git diff --check`

Note: `bun` is not available in this local shell, so I installed dependencies with `npm install --no-package-lock` and used the available npm/biome build tooling for focused verification.
