### PR TITLE
Rename disabled focus fixture

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- rename the remaining legacy `DisabledAutoFocus` board fixture to `FocusOnHoverDisabled`
- make the fixture explicitly pass `focusOnHover={false}`

/claim #163

## Verification
- rg -n "disableAutoFocus|DisabledAutoFocus" src README.md tests
- npx --yes bun x biome check src/examples/2025/board.fixture.tsx
- npx --yes bun test
- npx --yes bun x tsc --noEmit
- npx --yes bun run build
- git diff --check