### PR TITLE
fix: Remove `disableAutoFocus` in favor of `focusOnHover={false}`

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,20 +112,6 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
-  const circuit = new Circuit()
-
-  circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
-
-  const soup = circuit.getCircuitJson()
-
-  return (
-    <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
-    </div>
-  )
-}
-
 export default {
   BasicRectangleBoard,
   TriangleBoard,


### PR DESCRIPTION
Closes #163.

Removed the orphaned `DisabledAutoFocus` fixture export in `src/examples/2025/board.fixture.tsx` — it was a leftover artifact of the old `disableAutoFocus` prop (which no longer exists in the source) and rendered `<PCBViewer>` with no prop at all, making it dead/misleading code. The `focusOnHover={false}` behavior is already the default and is properly demonstrated in `hover-behavior.fixture.tsx` (`HoverDisabled`). Typecheck passes clean.

Tests: PASS

---
_Bounty attempt._