### PR TITLE
fix: rename DisabledAutoFocus fixture to HoverFocusDisabled with focusOnHover={false}

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const HoverFocusDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }
@@ -131,4 +131,5 @@ export default {
   TriangleBoard,
   OctagonBoard,
   AtariBoard,
+  HoverFocusDisabled,
 }


### PR DESCRIPTION
/claim #163

Rename the legacy `DisabledAutoFocus` fixture to `HoverFocusDisabled` and explicitly pass `focusOnHover={false}`.

- Renames the fixture to match the existing `focusOnHover` naming convention
- Adds explicit `focusOnHover={false}` prop
- Adds the renamed fixture to the default export