### PR TITLE
Fix PCBViewer attribute update invalidation

### DIFF
--- a/src/PCBViewer.tsx
+++ b/src/PCBViewer.tsx
@@ -13,7 +13,6 @@ import { CanvasElementsRenderer } from "./components/CanvasElementsRenderer"
 import type { BoundsSelection } from "./components/DimensionOverlay"
 import type { ManualEditEvent } from "@tscircuit/props"
 import { zIndexMap } from "lib/util/z-index-map"
-import { calculateCircuitJsonKey } from "lib/calculate-circuit-json-key"
 import { calculateBoardSizeKey } from "lib/calculate-board-size-key"
 
 const defaultTransform = compose(translate(400, 300), scale(40, -40))
@@ -76,10 +75,6 @@ export const PCBViewer = ({
 
   const initialRenderCompleted = useRef(false)
   const touchStartRef = useRef<{ x: number; y: number } | null>(null)
-  const circuitJsonKey = useMemo(
-    () => calculateCircuitJsonKey(circuitJson),
-    [circuitJson],
-  )
   const boardSizeKey = calculateBoardSizeKey(circuitJson)
 
   const resetTransform = () => {
@@ -132,7 +127,7 @@ export const PCBViewer = ({
         (e: any) => e.type.startsWith("pcb_") || e.type.startsWith("source_"),
       ) ?? []
     )
-  }, [circuitJsonKey])
+  }, [circuitJson])
 
   const elements = useMemo(() => {
     return applyEditEvents({


### PR DESCRIPTION
## Summary
- Make `pcbElmsPreEdit` depend directly on `circuitJson` instead of the narrower `circuitJsonKey`.
- This fixes stale PCB renders when element attributes change, such as `fontSize`, instead of only when elements are added or removed.
- Remove the now-unused `calculateCircuitJsonKey` memo/import.

## Verification
- `bunx tsc --noEmit --pretty false`
