### PR TITLE
fix: replace DisabledAutoFocus with focusOnHover={false}

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const BoardWithFocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }
@@ -131,4 +131,5 @@ export default {
   TriangleBoard,
   OctagonBoard,
   AtariBoard,
+  BoardWithFocusOnHoverDisabled,
 }


### PR DESCRIPTION
Removes the legacy \DisabledAutoFocus\ fixture and replaces it with \BoardWithFocusOnHoverDisabled\ that explicitly uses \ocusOnHover={false}\. Fixes tscircuit/pcb-viewer#163

/claim #163