### PR TITLE
Rename disabled autofocus fixture

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

/claim #163

- Renames the remaining legacy `DisabledAutoFocus` fixture to `FocusOnHoverDisabled`.
- Makes the fixture explicitly pass `focusOnHover={false}` so it uses the current prop terminology.
- Leaves the runtime implementation unchanged; this is a focused example cleanup.

## Validation

- `rg -n "disableAutoFocus|DisabledAutoFocus" src README.md package.json` -> no matches
- `npx biome check src/examples/2025/board.fixture.tsx`
- `npm run build`
- `git diff --check`

Note: this environment does not have `bun`, so I installed dependencies with `npm install --no-package-lock --legacy-peer-deps` for local validation without changing the lockfile.