### PR TITLE
Match KiCad layer behavior by reordering the selected layer instead of hiding other layers

### DIFF
--- a/src/examples/2025/multi-layer/overlapping-layers-test.fixture.tsx
+++ b/src/examples/2025/multi-layer/overlapping-layers-test.fixture.tsx
@@ -124,7 +124,10 @@ const OverlappingLayersTest = () => {
             Continue testing each layer - the selected layer should ALWAYS be on
             top
           </li>
-          <li>All other layers should be visible at 50% opacity beneath</li>
+          <li>
+            All other layers should remain visible beneath it without dimming or
+            hiding
+          </li>
         </ul>
         <p style={{ fontSize: "14px", opacity: 0.8, marginTop: "10px" }}>
           Use hotkeys 1-8 or the layer dropdown to switch between layers

--- a/src/lib/Drawer.ts
+++ b/src/lib/Drawer.ts
@@ -497,7 +497,8 @@ export class Drawer {
    * Iterate over each canvas and set the z index based on the layer order, but
    * always render the foreground layer on top.
    *
-   * Also: Set the opacity of every non-foreground layer to 0.5
+   * Also: Hide non-active layers while keeping board/drill/edge cuts and
+   * same-side helper layers visible.
    */
   orderAndFadeLayers() {
     const { canvasLayerMap, foregroundLayer } = this
@@ -532,7 +533,7 @@ export class Drawer {
           ? "bottom_courtyard"
           : undefined
 
-    const opaqueLayers = new Set<string>([
+    const visibleLayers = new Set<string>([
       foregroundLayer,
       "drill",
       "edge_cuts",
@@ -567,12 +568,18 @@ export class Drawer {
       "drill",
     ]
 
+    for (const canvas of Object.values(canvasLayerMap)) {
+      canvas.style.opacity = "0"
+      canvas.style.visibility = "hidden"
+    }
+
     order.forEach((layer, i) => {
       const canvas = canvasLayerMap[layer]
       if (!canvas) return
 
       canvas.style.zIndex = `${zIndexMap.topLayer - (order.length - i)}`
-      canvas.style.opacity = opaqueLayers.has(layer) ? "1" : "0.5"
+      canvas.style.opacity = visibleLayers.has(layer) ? "1" : "0"
+      canvas.style.visibility = visibleLayers.has(layer) ? "visible" : "hidden"
     })
   }
 

--- a/src/lib/Drawer.ts
+++ b/src/lib/Drawer.ts
@@ -494,92 +494,40 @@ export class Drawer {
   }
 
   /**
-   * Iterate over each canvas and set the z index based on the layer order, but
-   * always render the foreground layer on top.
+   * Iterate over each canvas and set the z index based on the layer order while
+   * always rendering the foreground layer above every other board layer.
    *
-   * Also: Hide non-active layers while keeping board/drill/edge cuts and
-   * same-side helper layers visible.
+   * All layers remain visible; switching layers only changes stacking order.
+   * Drill holes and edge cuts stay above the selected layer so holes and board
+   * outlines remain readable.
    */
   orderAndFadeLayers() {
     const { canvasLayerMap, foregroundLayer } = this
-    const associatedSoldermask =
-      foregroundLayer === "top"
-        ? "soldermask_top"
-        : foregroundLayer === "bottom"
-          ? "soldermask_bottom"
-          : undefined
-    const associatedSilkscreen =
-      foregroundLayer === "top"
-        ? "top_silkscreen"
-        : foregroundLayer === "bottom"
-          ? "bottom_silkscreen"
-          : undefined
-    const associatedNotes =
-      foregroundLayer === "top"
-        ? "top_notes"
-        : foregroundLayer === "bottom"
-          ? "bottom_notes"
-          : undefined
-    const associatedFabrication =
-      foregroundLayer === "top"
-        ? "top_fabrication"
-        : foregroundLayer === "bottom"
-          ? "bottom_fabrication"
-          : undefined
-    const associatedCourtyard =
-      foregroundLayer === "top"
-        ? "top_courtyard"
-        : foregroundLayer === "bottom"
-          ? "bottom_courtyard"
-          : undefined
-
-    const visibleLayers = new Set<string>([
-      foregroundLayer,
-      "drill",
-      "edge_cuts",
-      "other",
-      "board",
-      ...(associatedSoldermask ? [associatedSoldermask] : []),
-      ...(associatedSilkscreen ? [associatedSilkscreen] : []),
-      ...(associatedNotes ? [associatedNotes] : []),
-      ...(associatedFabrication ? [associatedFabrication] : []),
-      ...(associatedCourtyard ? [associatedCourtyard] : []),
-    ])
-
-    const layersToShiftToTop = [
-      foregroundLayer,
-      "edge_cuts",
-      ...(associatedSoldermask ? [associatedSoldermask] : []),
-      ...(associatedSilkscreen ? [associatedSilkscreen] : []),
-      ...(associatedNotes ? [associatedNotes] : []),
-      ...(associatedFabrication ? [associatedFabrication] : []),
-      ...(associatedCourtyard ? [associatedCourtyard] : []),
+    const fixedTopLayers = ["edge_cuts", "drill"]
+    const baseOrder = [
+      ...DEFAULT_DRAW_ORDER.filter((layer) => layer in canvasLayerMap),
+      ...Object.keys(canvasLayerMap).filter(
+        (layer) => !DEFAULT_DRAW_ORDER.includes(layer as any),
+      ),
     ]
-
+    const activeLayerExists = foregroundLayer in canvasLayerMap
     const order = [
-      ...DEFAULT_DRAW_ORDER.filter((l) => !layersToShiftToTop.includes(l)),
-      ...(foregroundLayer === "drill" ? [] : [foregroundLayer]),
-      ...(associatedSoldermask ? [associatedSoldermask] : []),
-      "edge_cuts",
-      ...(associatedSilkscreen ? [associatedSilkscreen] : []),
-      ...(associatedNotes ? [associatedNotes] : []),
-      ...(associatedFabrication ? [associatedFabrication] : []),
-      ...(associatedCourtyard ? [associatedCourtyard] : []),
-      "drill",
+      ...baseOrder.filter(
+        (layer) => layer !== foregroundLayer && !fixedTopLayers.includes(layer),
+      ),
+      ...(activeLayerExists ? [foregroundLayer] : []),
+      ...fixedTopLayers.filter(
+        (layer) => layer in canvasLayerMap && layer !== foregroundLayer,
+      ),
     ]
-
-    for (const canvas of Object.values(canvasLayerMap)) {
-      canvas.style.opacity = "0"
-      canvas.style.visibility = "hidden"
-    }
 
     order.forEach((layer, i) => {
       const canvas = canvasLayerMap[layer]
       if (!canvas) return
 
       canvas.style.zIndex = `${zIndexMap.topLayer - (order.length - i)}`
-      canvas.style.opacity = visibleLayers.has(layer) ? "1" : "0"
-      canvas.style.visibility = visibleLayers.has(layer) ? "visible" : "hidden"
+      canvas.style.opacity = "1"
+      canvas.style.visibility = "visible"
     })
   }
 

--- a/tests/lib/drawer.test.ts
+++ b/tests/lib/drawer.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "bun:test"
+import { Drawer } from "../../src/lib/Drawer"
+
+const createFakeCanvas = () =>
+  ({
+    style: {},
+    getContext: () => ({ canvas: { width: 0, height: 0 } }),
+  }) as unknown as HTMLCanvasElement
+
+describe("Drawer.orderAndFadeLayers", () => {
+  it("keeps every layer visible while lifting the selected top layer above other board layers", () => {
+    const drawer = new Drawer({
+      board: createFakeCanvas(),
+      bottom: createFakeCanvas(),
+      top: createFakeCanvas(),
+      top_silkscreen: createFakeCanvas(),
+      edge_cuts: createFakeCanvas(),
+      drill: createFakeCanvas(),
+    })
+
+    drawer.foregroundLayer = "top"
+    drawer.orderAndFadeLayers()
+
+    expect(drawer.canvasLayerMap.bottom.style.opacity).toBe("1")
+    expect(drawer.canvasLayerMap.bottom.style.visibility).toBe("visible")
+    expect(drawer.canvasLayerMap.top.style.opacity).toBe("1")
+    expect(drawer.canvasLayerMap.top.style.visibility).toBe("visible")
+    expect(Number(drawer.canvasLayerMap.top.style.zIndex)).toBeGreaterThan(
+      Number(drawer.canvasLayerMap.bottom.style.zIndex),
+    )
+    expect(Number(drawer.canvasLayerMap.top.style.zIndex)).toBeGreaterThan(
+      Number(drawer.canvasLayerMap.top_silkscreen.style.zIndex),
+    )
+  })
+
+  it("reorders the stack when switching to the bottom layer without hiding other layers", () => {
+    const drawer = new Drawer({
+      top: createFakeCanvas(),
+      inner1: createFakeCanvas(),
+      bottom: createFakeCanvas(),
+      edge_cuts: createFakeCanvas(),
+      drill: createFakeCanvas(),
+    })
+
+    drawer.foregroundLayer = "bottom"
+    drawer.orderAndFadeLayers()
+
+    expect(drawer.canvasLayerMap.top.style.opacity).toBe("1")
+    expect(drawer.canvasLayerMap.top.style.visibility).toBe("visible")
+    expect(drawer.canvasLayerMap.inner1.style.opacity).toBe("1")
+    expect(drawer.canvasLayerMap.inner1.style.visibility).toBe("visible")
+    expect(Number(drawer.canvasLayerMap.bottom.style.zIndex)).toBeGreaterThan(
+      Number(drawer.canvasLayerMap.top.style.zIndex),
+    )
+    expect(Number(drawer.canvasLayerMap.bottom.style.zIndex)).toBeGreaterThan(
+      Number(drawer.canvasLayerMap.inner1.style.zIndex),
+    )
+  })
+})


### PR DESCRIPTION
test: https://pcb-viewer-6urhaz607-tscircuit.vercel.app/?fixture=%7B%22path%22%3A%22src%2Fexamples%2F2026%2Frepros%2Foverlapping-inner-layer-copper-pours.fixture.tsx%22%7D




Previously, selecting a layer could hide or dim other layers. Now, all layers remain visible, and the selected layer is simply brought above the other board layers in the stack.

## Changes

- removed layer-isolation visibility logic from `Drawer.orderAndFadeLayers()`
- kept all layers visible at full opacity
- reordered canvas z-index so the selected layer is rendered above other board layers
- kept `drill` and `edge_cuts` readable at the top of the stack
- updated the overlapping multi-layer fixture text to match the new behavior
- added a `Drawer` test to lock in the stacking behavior

## Why

This matches the expected KiCad interaction more closely:

- default `top` selection should still show the full board
- selecting another layer should not hide the rest of the PCB
- the selected layer should come to the front for easier inspection
