### PR TITLE
fix: remove DisabledAutoFocus in favor of focusOnHover={false}

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }
@@ -131,4 +131,5 @@ export default {
   TriangleBoard,
   OctagonBoard,
   AtariBoard,
+  FocusOnHoverDisabled,
 }


### PR DESCRIPTION
## Summary

Removes the `DisabledAutoFocus` fixture naming convention in favor of using `focusOnHover={false}` prop explicitly.

### Changes:
- Renamed `DisabledAutoFocus` fixture to `FocusOnHoverDisabled` for clarity
- Added explicit `focusOnHover={false}` prop to the PCBViewer component in the fixture
- Added `FocusOnHoverDisabled` to default exports

Closes #163

/claim #163

ETH wallet: 0x911d202f713Ee2ad139E8b8b8a0A712347eFE31f