### PR TITLE
fix: use focusOnHover={false} instead of DisabledAutoFocus fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The PCBViewer component accepts these props:
 - `editEvents`: Array of edit events to apply
 - `onEditEventsChanged`: Callback when edit events change
 - `onBoundsSelected`: Callback when the Bounds tool completes a rectangle selection. Receives `{ minX, minY, maxX, maxY }`.
+- `focusOnHover`: When `true`, pans the viewport to keep hovered elements in view. Use `focusOnHover={false}` to disable (replaces the legacy `disableAutoFocus` pattern).
 - `initialState`: Initial state for the viewer
 
 ### Features

--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
Fixes #163

/claim #163

## What changed
- Renamed `DisabledAutoFocus` fixture export to `FocusOnHoverDisabled`
- Pass `focusOnHover={false}` on `PCBViewer` to replace the legacy disableAutoFocus pattern

## How to verify
1. Open the `FocusOnHoverDisabled` board fixture in react-cosmos / dev tools
2. Confirm hover does not steal focus (same as previous DisabledAutoFocus intent)
3. `HoverDisabled` in hover-behavior.fixture.tsx remains the primary hover demo

Made with [Cursor](https://cursor.com)