### PR TITLE
fix(examples): update keepout fixture layer field and circle layer value

### DIFF
--- a/src/examples/2025/keepout-layer.fixture.tsx
+++ b/src/examples/2025/keepout-layer.fixture.tsx
@@ -17,7 +17,7 @@ export const KeepoutMultiLayerExample = () => {
     {
       type: "pcb_keepout",
       pcb_keepout_id: "pcb_keepout_top",
-      layer: ["top"],
+      layers: ["top"],
       shape: "rect",
       width: 3,
       height: 2,
@@ -26,7 +26,7 @@ export const KeepoutMultiLayerExample = () => {
     {
       type: "pcb_keepout",
       pcb_keepout_id: "pcb_keepout_inner1",
-      layer: ["top"],
+      layers: ["top"],
       shape: "rect",
       width: 3,
       height: 2,
@@ -35,7 +35,7 @@ export const KeepoutMultiLayerExample = () => {
     {
       type: "pcb_keepout",
       pcb_keepout_id: "pcb_keepout_inner2",
-      layer: ["top"],
+      layers: ["top"],
       shape: "circle",
       radius: 1.5,
       center: { x: 3, y: 0 },
@@ -43,7 +43,7 @@ export const KeepoutMultiLayerExample = () => {
     {
       type: "pcb_keepout",
       pcb_keepout_id: "pcb_keepout_inner3",
-      layer: ["top"],
+      layers: ["top"],
       shape: "rect",
       width: 3,
       height: 2,
@@ -52,7 +52,7 @@ export const KeepoutMultiLayerExample = () => {
     {
       type: "pcb_keepout",
       pcb_keepout_id: "pcb_keepout_bottom",
-      layer: ["top"],
+      layers: ["top"],
       shape: "circle",
       radius: 1.5,
       center: { x: -9, y: -6 },
@@ -60,7 +60,7 @@ export const KeepoutMultiLayerExample = () => {
     {
       type: "pcb_keepout",
       pcb_keepout_id: "pcb_keepout_multi",
-      layer: ["top"],
+      layers: ["top"],
       shape: "rect",
       width: 2,
       height: 2,

--- a/src/examples/2025/keepout.fixture.tsx
+++ b/src/examples/2025/keepout.fixture.tsx
@@ -306,7 +306,7 @@ export const KeepoutRectExample = () => {
             {
               type: "pcb_keepout",
               pcb_keepout_id: "pcb_keepout_0",
-              layer: ["top"],
+              layers: ["top"],
               shape: "rect",
               width: 1,
               height: 1,
@@ -682,7 +682,7 @@ export const KeepoutCircleExample = () => {
             {
               type: "pcb_keepout",
               pcb_keepout_id: "pcb_keepout_0",
-              layer: ["top"],
+              layers: ["bottom"],
               shape: "circle",
               radius: 1,
               center: {


### PR DESCRIPTION
Fixtures and examples were failing cause circuit-json was wrong

## Before
<img width="1697" height="998" alt="image" src="https://github.com/user-attachments/assets/4db24b6d-bd0e-449b-b76b-3628d560d0ef" />

## After
<img width="1697" height="998" alt="image" src="https://github.com/user-attachments/assets/dab4cbb2-2b28-4eaf-a144-bf9b9e1b63aa" />

Verification of correct circuit-json

<img width="1697" height="998" alt="image" src="https://github.com/user-attachments/assets/5e59506a-0890-40fc-bc5b-bb698e877ec3" />


