### PR TITLE
fix: replace disabled autofocus fixture

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- Renames the remaining `DisabledAutoFocus` fixture to `FocusOnHoverDisabled`
- Makes the replacement behavior explicit with `focusOnHover={false}`

Closes #163
/claim #163

## Test Plan
- `npm run format:check`
- `npm run build`
- `git diff --check`
- `git grep -n "disableAutoFocus\|DisabledAutoFocus" -- . ":!node_modules" || true`
