### PR TITLE
feat: add component side visibility toggles

### DIFF
--- a/src/components/CanvasElementsRenderer.tsx
+++ b/src/components/CanvasElementsRenderer.tsx
@@ -1,25 +1,27 @@
+import type { ManualEditEvent } from "@tscircuit/props"
 import type { AnyCircuitElement } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import type { GraphicsObject } from "graphics-debug"
+import { convertElementToPrimitives } from "lib/convert-element-to-primitive"
+import { filterElementsByComponentSideVisibility } from "lib/filter-elements-by-component-side-visibility"
 import type { GridConfig, Primitive } from "lib/types"
 import { addInteractionMetadataToPrimitives } from "lib/util/addInteractionMetadataToPrimitives"
-import { findErrorElementById, getErrorId } from "lib/util/get-error-id"
 import {
   buildErrorPreviewElementIndexes,
   createTransformForBounds,
   getErrorPreviewBounds,
   getRelatedIdsForError,
 } from "lib/util/error-preview"
+import { findErrorElementById, getErrorId } from "lib/util/get-error-id"
 import {
   animateTransform,
   cancelTransformAnimation,
 } from "lib/util/transform-animation"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { type Matrix } from "transformation-matrix"
-import { convertElementToPrimitives } from "lib/convert-element-to-primitive"
+import type { Matrix } from "transformation-matrix"
+import { useGlobalStore } from "../global-store"
 import { CanvasPrimitiveRenderer } from "./CanvasPrimitiveRenderer"
 import { DebugGraphicsOverlay } from "./DebugGraphicsOverlay"
-import { WarningGraphicsOverlay } from "./WarningGraphicsOverlay"
 import { type BoundsSelection, DimensionOverlay } from "./DimensionOverlay"
 import { EditPlacementOverlay } from "./EditPlacementOverlay"
 import { EditTraceHintOverlay } from "./EditTraceHintOverlay"
@@ -28,8 +30,7 @@ import { MouseElementTracker } from "./MouseElementTracker"
 import { PcbGroupOverlay } from "./PcbGroupOverlay"
 import { RatsNestOverlay } from "./RatsNestOverlay"
 import { ToolbarOverlay } from "./ToolbarOverlay"
-import type { ManualEditEvent } from "@tscircuit/props"
-import { useGlobalStore } from "../global-store"
+import { WarningGraphicsOverlay } from "./WarningGraphicsOverlay"
 
 export interface CanvasElementsRendererProps {
   elements: AnyCircuitElement[]
@@ -49,20 +50,35 @@ export interface CanvasElementsRendererProps {
 
 export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
   const { transform, elements } = props
-  const { hoveredErrorId, focusedErrorId, isShowingCopperPours } =
-    useGlobalStore((state) => ({
-      hoveredErrorId: state.hovered_error_id,
-      focusedErrorId: state.focused_error_id,
-      isShowingCopperPours: state.is_showing_copper_pours,
-    }))
+  const {
+    hoveredErrorId,
+    focusedErrorId,
+    isShowingCopperPours,
+    isShowingTopComponents,
+    isShowingBottomComponents,
+  } = useGlobalStore((state) => ({
+    hoveredErrorId: state.hovered_error_id,
+    focusedErrorId: state.focused_error_id,
+    isShowingCopperPours: state.is_showing_copper_pours,
+    isShowingTopComponents: state.is_showing_top_components,
+    isShowingBottomComponents: state.is_showing_bottom_components,
+  }))
   const activeErrorId = focusedErrorId ?? hoveredErrorId
 
   const elementsToRender = useMemo(
     () =>
-      isShowingCopperPours
-        ? elements
-        : elements.filter((elm) => elm.type !== "pcb_copper_pour"),
-    [elements, isShowingCopperPours],
+      filterElementsByComponentSideVisibility(elements, {
+        showTopComponents: isShowingTopComponents,
+        showBottomComponents: isShowingBottomComponents,
+      }).filter(
+        (elm) => isShowingCopperPours || elm.type !== "pcb_copper_pour",
+      ),
+    [
+      elements,
+      isShowingBottomComponents,
+      isShowingCopperPours,
+      isShowingTopComponents,
+    ],
   )
 
   const [primitivesWithoutInteractionMetadata, connectivityMap] =

--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -1,20 +1,20 @@
-import {
-  useEffect,
-  useState,
-  useCallback,
-  useRef,
-  useLayoutEffect,
-} from "react"
 import { css } from "@emotion/css"
-import { type LayerRef } from "circuit-json"
+import type { LayerRef } from "circuit-json"
 import type { AnyCircuitElement } from "circuit-json"
-import { LAYER_NAME_TO_COLOR } from "lib/Drawer"
-import { useGlobalStore } from "../global-store"
-import packageJson from "../../package.json"
 import { useHotKey } from "hooks/useHotKey"
-import { zIndexMap } from "lib/util/z-index-map"
 import { useIsSmallScreen } from "hooks/useIsSmallScreen"
 import { useMobileTouch } from "hooks/useMobileTouch"
+import { LAYER_NAME_TO_COLOR } from "lib/Drawer"
+import { zIndexMap } from "lib/util/z-index-map"
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react"
+import packageJson from "../../package.json"
+import { useGlobalStore } from "../global-store"
 import { ToolbarButton } from "./ToolbarButton"
 import { ToolbarErrorDropdown } from "./ToolbarErrorDropdown"
 
@@ -155,6 +155,8 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     setIsShowingSolderMask,
     setIsShowingSilkscreen,
     setIsShowingFabricationNotes,
+    setIsShowingTopComponents,
+    setIsShowingBottomComponents,
     setPcbGroupViewMode,
     setHoveredErrorId,
     setFocusedErrorId,
@@ -179,6 +181,8 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
       is_showing_solder_mask: s.is_showing_solder_mask,
       is_showing_silkscreen: s.is_showing_silkscreen,
       is_showing_fabrication_notes: s.is_showing_fabrication_notes,
+      is_showing_top_components: s.is_showing_top_components,
+      is_showing_bottom_components: s.is_showing_bottom_components,
       pcb_group_view_mode: s.pcb_group_view_mode,
     },
     setEditMode: s.setEditMode,
@@ -193,6 +197,8 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     setIsShowingSolderMask: s.setIsShowingSolderMask,
     setIsShowingSilkscreen: s.setIsShowingSilkscreen,
     setIsShowingFabricationNotes: s.setIsShowingFabricationNotes,
+    setIsShowingTopComponents: s.setIsShowingTopComponents,
+    setIsShowingBottomComponents: s.setIsShowingBottomComponents,
     setPcbGroupViewMode: s.setPcbGroupViewMode,
     setHoveredErrorId: s.setHoveredErrorId,
     setFocusedErrorId: s.setFocusedErrorId,
@@ -609,6 +615,24 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
                   checked={viewSettings.is_showing_silkscreen}
                   onClick={() => {
                     setIsShowingSilkscreen(!viewSettings.is_showing_silkscreen)
+                  }}
+                />
+                <CheckboxMenuItem
+                  label="Show Top Components"
+                  checked={viewSettings.is_showing_top_components}
+                  onClick={() => {
+                    setIsShowingTopComponents(
+                      !viewSettings.is_showing_top_components,
+                    )
+                  }}
+                />
+                <CheckboxMenuItem
+                  label="Show Bottom Components"
+                  checked={viewSettings.is_showing_bottom_components}
+                  onClick={() => {
+                    setIsShowingBottomComponents(
+                      !viewSettings.is_showing_bottom_components,
+                    )
                   }}
                 />
                 <CheckboxMenuItem

--- a/src/global-store.ts
+++ b/src/global-store.ts
@@ -1,16 +1,16 @@
+import type { LayerRef } from "circuit-json"
+import { useContext } from "react"
 import {
   createStore as createZustandStore,
   useStore as useZustandStore,
 } from "zustand"
 import { StoreContext } from "./components/ContextProviders"
-import type { LayerRef } from "circuit-json"
-import { useContext } from "react"
 import {
+  STORAGE_KEYS,
   getStoredBoolean,
   getStoredString,
   setStoredBoolean,
   setStoredString,
-  STORAGE_KEYS,
 } from "./hooks/useLocalStorage"
 
 export interface State {
@@ -36,6 +36,8 @@ export interface State {
   is_showing_solder_mask: boolean
   is_showing_silkscreen: boolean
   is_showing_fabrication_notes: boolean
+  is_showing_top_components: boolean
+  is_showing_bottom_components: boolean
   pcb_group_view_mode: "all" | "named_only"
 
   hovered_error_id: string | null
@@ -57,6 +59,8 @@ export interface State {
   setIsShowingSolderMask: (is_showing: boolean) => void
   setIsShowingSilkscreen: (is_showing: boolean) => void
   setIsShowingFabricationNotes: (is_showing: boolean) => void
+  setIsShowingTopComponents: (is_showing: boolean) => void
+  setIsShowingBottomComponents: (is_showing: boolean) => void
   setPcbGroupViewMode: (mode: "all" | "named_only") => void
   setHoveredErrorId: (errorId: string | null) => void
   setFocusedErrorId: (errorId: string | null) => void
@@ -118,6 +122,14 @@ export const createStore = (
         is_showing_fabrication_notes: getStoredBoolean(
           STORAGE_KEYS.IS_SHOWING_FABRICATION_NOTES,
           false,
+        ),
+        is_showing_top_components: getStoredBoolean(
+          STORAGE_KEYS.IS_SHOWING_TOP_COMPONENTS,
+          true,
+        ),
+        is_showing_bottom_components: getStoredBoolean(
+          STORAGE_KEYS.IS_SHOWING_BOTTOM_COMPONENTS,
+          true,
         ),
         pcb_group_view_mode: disablePcbGroups
           ? "all"
@@ -187,6 +199,17 @@ export const createStore = (
             is_showing,
           )
           set({ is_showing_fabrication_notes: is_showing })
+        },
+        setIsShowingTopComponents: (is_showing) => {
+          setStoredBoolean(STORAGE_KEYS.IS_SHOWING_TOP_COMPONENTS, is_showing)
+          set({ is_showing_top_components: is_showing })
+        },
+        setIsShowingBottomComponents: (is_showing) => {
+          setStoredBoolean(
+            STORAGE_KEYS.IS_SHOWING_BOTTOM_COMPONENTS,
+            is_showing,
+          )
+          set({ is_showing_bottom_components: is_showing })
         },
         setPcbGroupViewMode: (mode) => {
           if (disablePcbGroups) return

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -9,6 +9,8 @@ export const STORAGE_KEYS = {
   IS_SHOWING_SOLDER_MASK: "pcb_viewer_is_showing_solder_mask",
   IS_SHOWING_FABRICATION_NOTES: "pcb_viewer_is_showing_fabrication_notes",
   IS_SHOWING_SILKSCREEN: "pcb_viewer_is_showing_silkscreen",
+  IS_SHOWING_TOP_COMPONENTS: "pcb_viewer_is_showing_top_components",
+  IS_SHOWING_BOTTOM_COMPONENTS: "pcb_viewer_is_showing_bottom_components",
 } as const
 
 export const getStoredBoolean = (

--- a/src/lib/filter-elements-by-component-side-visibility.ts
+++ b/src/lib/filter-elements-by-component-side-visibility.ts
@@ -1,0 +1,96 @@
+import type { AnyCircuitElement } from "circuit-json"
+
+type ComponentSideVisibility = {
+  showTopComponents: boolean
+  showBottomComponents: boolean
+}
+
+const getElementComponentId = (element: AnyCircuitElement) => {
+  return "pcb_component_id" in element
+    ? (element.pcb_component_id as string | undefined)
+    : undefined
+}
+
+const isLayerHidden = (
+  layer: string | undefined,
+  { showTopComponents, showBottomComponents }: ComponentSideVisibility,
+) => {
+  if (layer === "top") return !showTopComponents
+  if (layer === "bottom") return !showBottomComponents
+  return false
+}
+
+const getElementLayer = (element: AnyCircuitElement) => {
+  if ("layer" in element && typeof element.layer === "string") {
+    return element.layer
+  }
+
+  if ("layers" in element && Array.isArray(element.layers)) {
+    if (element.layers.includes("top")) return "top"
+    if (element.layers.includes("bottom")) return "bottom"
+  }
+
+  return undefined
+}
+
+const getComponentLayer = (
+  component: AnyCircuitElement,
+  elements: AnyCircuitElement[],
+) => {
+  const componentLayer = getElementLayer(component)
+  if (componentLayer) return componentLayer
+
+  const componentId = getElementComponentId(component)
+  if (!componentId) return undefined
+
+  const childElement = elements.find(
+    (element) =>
+      element.type !== "pcb_component" &&
+      getElementComponentId(element) === componentId &&
+      getElementLayer(element),
+  )
+
+  return childElement ? getElementLayer(childElement) : undefined
+}
+
+const componentHasPlatedHole = (
+  componentId: string,
+  elements: AnyCircuitElement[],
+) => {
+  return elements.some(
+    (element) =>
+      element.type === "pcb_plated_hole" &&
+      getElementComponentId(element) === componentId,
+  )
+}
+
+export const filterElementsByComponentSideVisibility = (
+  elements: AnyCircuitElement[],
+  visibility: ComponentSideVisibility,
+) => {
+  if (visibility.showTopComponents && visibility.showBottomComponents) {
+    return elements
+  }
+
+  const hiddenComponentIds = new Set<string>()
+
+  for (const element of elements) {
+    if (element.type !== "pcb_component") continue
+
+    const componentId = getElementComponentId(element)
+    if (!componentId) continue
+    if (componentHasPlatedHole(componentId, elements)) continue
+
+    const layer = getComponentLayer(element, elements)
+    if (isLayerHidden(layer, visibility)) {
+      hiddenComponentIds.add(componentId)
+    }
+  }
+
+  if (hiddenComponentIds.size === 0) return elements
+
+  return elements.filter((element) => {
+    const componentId = getElementComponentId(element)
+    return !componentId || !hiddenComponentIds.has(componentId)
+  })
+}

--- a/tests/lib/filter-elements-by-component-side-visibility.test.ts
+++ b/tests/lib/filter-elements-by-component-side-visibility.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { filterElementsByComponentSideVisibility } from "lib/filter-elements-by-component-side-visibility"
+
+const elements = [
+  {
+    type: "pcb_component",
+    pcb_component_id: "top_component",
+    layer: "top",
+  },
+  {
+    type: "pcb_smtpad",
+    pcb_smtpad_id: "top_pad",
+    pcb_component_id: "top_component",
+    layer: "top",
+  },
+  {
+    type: "pcb_component",
+    pcb_component_id: "bottom_component",
+    layer: "bottom",
+  },
+  {
+    type: "pcb_smtpad",
+    pcb_smtpad_id: "bottom_pad",
+    pcb_component_id: "bottom_component",
+    layer: "bottom",
+  },
+  {
+    type: "pcb_component",
+    pcb_component_id: "through_hole_component",
+    layer: "top",
+  },
+  {
+    type: "pcb_plated_hole",
+    pcb_plated_hole_id: "through_hole",
+    pcb_component_id: "through_hole_component",
+    layers: ["top", "bottom"],
+  },
+  {
+    type: "pcb_trace",
+    pcb_trace_id: "trace",
+    layer: "top",
+  },
+] as AnyCircuitElement[]
+
+test("hides top-side SMT components and keeps through-hole components visible", () => {
+  const filtered = filterElementsByComponentSideVisibility(elements, {
+    showTopComponents: false,
+    showBottomComponents: true,
+  })
+
+  expect(filtered.map((element) => element.type)).toContain("pcb_trace")
+  expect(
+    filtered.some(
+      (element) =>
+        "pcb_component_id" in element &&
+        element.pcb_component_id === "top_component",
+    ),
+  ).toBe(false)
+  expect(
+    filtered.some(
+      (element) =>
+        "pcb_component_id" in element &&
+        element.pcb_component_id === "bottom_component",
+    ),
+  ).toBe(true)
+  expect(
+    filtered.some(
+      (element) =>
+        "pcb_component_id" in element &&
+        element.pcb_component_id === "through_hole_component",
+    ),
+  ).toBe(true)
+})
+
+test("hides bottom-side SMT components", () => {
+  const filtered = filterElementsByComponentSideVisibility(elements, {
+    showTopComponents: true,
+    showBottomComponents: false,
+  })
+
+  expect(
+    filtered.some(
+      (element) =>
+        "pcb_component_id" in element &&
+        element.pcb_component_id === "top_component",
+    ),
+  ).toBe(true)
+  expect(
+    filtered.some(
+      (element) =>
+        "pcb_component_id" in element &&
+        element.pcb_component_id === "bottom_component",
+    ),
+  ).toBe(false)
+})


### PR DESCRIPTION
Fixes #755

@algora-pbc /claim #755

## Summary
- Add persisted View menu toggles for `Show Top Components` and `Show Bottom Components`.
- Filter SMT-side component elements before primitive conversion/drawing while keeping through-hole components visible.
- Add regression coverage for hiding top/bottom SMT components without hiding plated-hole components.

## Verification
- `bun test`
- `bun test tests\lib\filter-elements-by-component-side-visibility.test.ts`
- `bun run build`
- `bun x biome check src\components\CanvasElementsRenderer.tsx src\components\ToolbarOverlay.tsx src\global-store.ts src\hooks\useLocalStorage.ts src\lib\filter-elements-by-component-side-visibility.ts tests\lib\filter-elements-by-component-side-visibility.test.ts`
- `git diff --check`