### PR TITLE
fix: rename hover fixture exports

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const HoverFocusDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }
@@ -131,4 +131,5 @@ export default {
   TriangleBoard,
   OctagonBoard,
   AtariBoard,
+  HoverFocusDisabled,
 }

--- a/src/examples/2025/hover-behavior.fixture.tsx
+++ b/src/examples/2025/hover-behavior.fixture.tsx
@@ -55,16 +55,16 @@ const HoverBehaviorDemo: React.FC<{ focusOnHover?: boolean }> = ({
 }
 
 // Story with hover focus disabled (default behavior)
-export const HoverDisabled = () => {
+export const FocusOnHoverDisabled = () => {
   return <HoverBehaviorDemo focusOnHover={false} />
 }
 
 // Story with hover focus enabled
-export const HoverEnabled = () => {
+export const FocusOnHoverEnabled = () => {
   return <HoverBehaviorDemo focusOnHover={true} />
 }
 
 export default {
-  HoverDisabled,
-  HoverEnabled,
+  FocusOnHoverDisabled,
+  FocusOnHoverEnabled,
 }


### PR DESCRIPTION
/claim #163`n`nRenames the remaining hover fixture exports to the current focusOnHover terminology and keeps `focusOnHover={false}` explicit in the example. Verified with `bun run build` and targeted `biome check` on the touched file.