### PR TITLE
chore(fixtures): remove stale DisabledAutoFocus story (closes #163)

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,20 +112,6 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
-  const circuit = new Circuit()
-
-  circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
-
-  const soup = circuit.getCircuitJson()
-
-  return (
-    <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
-    </div>
-  )
-}
-
 export default {
   BasicRectangleBoard,
   TriangleBoard,


### PR DESCRIPTION
## Closes #163

`disableAutoFocus` was already fully replaced by `focusOnHover={false}` in the source — the only remaining trace is a stale fixture in `src/examples/2025/board.fixture.tsx`:

```tsx
export const DisabledAutoFocus = () => {
  const circuit = new Circuit()
  circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
  const soup = circuit.getCircuitJson()
  return (
    <div style={{ backgroundColor: "black" }}>
      <PCBViewer circuitJson={soup as any} />
    </div>
  )
}
```

Two problems with this fixture as it stands:

1. **The name references a prop that no longer exists** (`disableAutoFocus`).
2. **It doesn't actually test focus behaviour** — the `PCBViewer` is rendered with no focus-related prop, so `focusOnHover` falls to its default (`false`, per `src/PCBViewer.tsx:44`). The story would look identical to plain `BasicRectangleBoard`.

Focus-on-hover is already covered end-to-end by `src/examples/2025/hover-behavior.fixture.tsx`, which exports both `HoverDisabled` (`focusOnHover={false}`) and `HoverEnabled` (`focusOnHover={true}`). Keeping the dead fixture just perpetuates confusion.

## Change

Deletes `DisabledAutoFocus` from `src/examples/2025/board.fixture.tsx`. Nothing else touched.

## Verification

- `grep -rn "disableAutoFocus\|DisabledAutoFocus" src` → no matches.
- `hover-behavior.fixture.tsx` continues to cover both states of `focusOnHover`.

## Why this over #877

PR #877 renames the fixture and passes `focusOnHover={false}`, but since `false` is the default, the fixture still does not verify any focus behaviour — it becomes a stylistic rename with the same underlying dead story. Removing the fixture is the honest completion of the migration.

/claim #163
