### PR TITLE
fix: rename DisabledAutoFocus fixture to FocusOnHoverDisabled

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
Fixes the last remaining legacy reference to `disableAutoFocus` in the codebase.

Changes:
- Renamed `DisabledAutoFocus` fixture export to `FocusOnHoverDisabled`
- Made `focusOnHover={false}` explicit on the PCBViewer component in that fixture

Verified:
- `rg -n disableAutoFocus|DisabledAutoFocus src` → no matches
- `tsc --noEmit` → no errors

/claim #163