### PR TITLE
fix: remove disableAutoFocus in favor of focusOnHover={false}

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }
@@ -131,4 +131,5 @@ export default {
   TriangleBoard,
   OctagonBoard,
   AtariBoard,
+  FocusOnHoverDisabled,
 }


### PR DESCRIPTION
## Summary

Removes the legacy \DisabledAutoFocus\ fixture name and replaces it with \FocusOnHoverDisabled\, explicitly passing \ocusOnHover={false}\ to \PCBViewer\.

## Changes
- Renamed \DisabledAutoFocus\ export to \FocusOnHoverDisabled\ in \oard.fixture.tsx\
- Added \ocusOnHover={false}\ prop to \PCBViewer\ in the fixture
- Added \FocusOnHoverDisabled\ to default exports

## Verification
- \
pm run build\ passes
- \
px biome check\ passes (formatted)

Closes #163

/claim #163