### PR TITLE
fix: remove thick red outline on pcb keepouts

### DIFF
--- a/src/lib/draw-pcb-keepout.ts
+++ b/src/lib/draw-pcb-keepout.ts
@@ -8,7 +8,10 @@ import type { Matrix } from "transformation-matrix"
 
 const KEEPOUT_COLOR_MAP: PcbColorMap = {
   ...DEFAULT_PCB_COLOR_MAP,
-  keepout: "rgba(255, 255, 255, 0.25)",
+  keepout: {
+    top: "rgba(255, 255, 255, 0.25)",
+    bottom: "rgba(255, 255, 255, 0.25)",
+  },
 }
 
 export function isPcbKeepout(element: AnyCircuitElement) {

--- a/src/lib/draw-pcb-keepout.ts
+++ b/src/lib/draw-pcb-keepout.ts
@@ -1,8 +1,15 @@
-import { CircuitToCanvasDrawer } from "circuit-to-canvas"
+import {
+  CircuitToCanvasDrawer,
+  DEFAULT_PCB_COLOR_MAP,
+  type PcbColorMap,
+} from "circuit-to-canvas"
 import type { AnyCircuitElement } from "circuit-json"
 import type { Matrix } from "transformation-matrix"
 
-// Color map for keepouts - uses background color for all layers
+const KEEPOUT_COLOR_MAP: PcbColorMap = {
+  ...DEFAULT_PCB_COLOR_MAP,
+  keepout: "rgba(255, 255, 255, 0.25)",
+}
 
 export function isPcbKeepout(element: AnyCircuitElement) {
   return element.type === "pcb_keepout"
@@ -26,6 +33,9 @@ export function drawPcbKeepoutElementsForLayer({
 
   const drawer = new CircuitToCanvasDrawer(canvas)
   drawer.realToCanvasMat = realToCanvasMat
+  drawer.configure({
+    colorOverrides: KEEPOUT_COLOR_MAP,
+  })
 
   drawer.drawElements(keepoutElements, { layers: [] })
 }


### PR DESCRIPTION
## Summary
- Configure keepout overlay to semi-transparent white instead of the default red border
- Keepouts remain visible via hatch pattern without harsh outline

Closes #47

/claim #47

Made with [Cursor](https://cursor.com)