### PR TITLE
fix: keep hover labels above copper pads

### DIFF
--- a/src/components/ElementOverlayBox.tsx
+++ b/src/components/ElementOverlayBox.tsx
@@ -19,6 +19,8 @@ const containerStyle = {
   fontFamily: "sans-serif",
   fontSize: 12,
   textShadow: "0 0 2px black",
+  // Keep hover labels above copper/canvas layers (pads render on canvases)
+  zIndex: zIndexMap.elementOverlay,
 } as const
 
 export const getTextForHighlightedPrimitive = (

--- a/src/lib/util/z-index-map.ts
+++ b/src/lib/util/z-index-map.ts
@@ -1,5 +1,6 @@
 export const zIndexMap = {
-  elementOverlay: 40,
+  // Hover labels must sit above all copper/canvas planes so pad text stays readable
+  elementOverlay: 50,
   dimensionOverlay: 40,
   editTraceHintOverlay: 40,
   errorOverlay: 40,


### PR DESCRIPTION
## Summary
- Raise element overlay z-index above canvas copper layers
- Set z-index on the hover overlay container so labels are not trapped behind pads

Closes #78