### PR TITLE
fix: prefer smallest overlapping component when dragging

### DIFF
--- a/src/components/EditPlacementOverlay.tsx
+++ b/src/components/EditPlacementOverlay.tsx
@@ -1,9 +1,10 @@
+import type { ManualEditEvent } from "@tscircuit/props"
 import type { AnyCircuitElement, PcbComponent } from "circuit-json"
-import { useGlobalStore } from "../global-store"
-import { useEffect, useRef, useState } from "react"
+import { useRef, useState } from "react"
 import type { Matrix } from "transformation-matrix"
 import { applyToPoint, identity, inverse } from "transformation-matrix"
-import type { ManualEditEvent } from "@tscircuit/props"
+import { useGlobalStore } from "../global-store"
+import { findSmallestPcbComponentAt } from "../lib/find-smallest-pcb-component-at"
 
 interface Props {
   transform?: Matrix
@@ -13,22 +14,6 @@ interface Props {
   cancelPanDrag: () => void
   onCreateEditEvent: (event: ManualEditEvent) => void
   onModifyEditEvent: (event: Partial<ManualEditEvent>) => void
-}
-
-const isInsideOf = (
-  pcb_component: PcbComponent,
-  point: { x: number; y: number },
-  padding = 0,
-) => {
-  const halfWidth = pcb_component.width / 2
-  const halfHeight = pcb_component.height / 2
-
-  const left = pcb_component.center.x - halfWidth - padding
-  const right = pcb_component.center.x + halfWidth + padding
-  const top = pcb_component.center.y - halfHeight - padding
-  const bottom = pcb_component.center.y + halfHeight + padding
-
-  return point.x > left && point.x < right && point.y > top && point.y < bottom
 }
 
 export const EditPlacementOverlay = ({
@@ -73,46 +58,43 @@ export const EditPlacementOverlay = ({
         if (Number.isNaN(x) || Number.isNaN(y)) return
         const rwMousePoint = applyToPoint(inverse(transform!), { x, y })
 
-        let foundActiveComponent = false
-        for (const e of soup) {
-          if (
-            e.type === "pcb_component" &&
-            isInsideOf(e, rwMousePoint, 10 / transform.a)
-          ) {
-            cancelPanDrag()
-            setActivePcbComponent(e.pcb_component_id)
-            foundActiveComponent = true
-            const edit_event_id = Math.random().toString()
-            setDragState({
-              dragStart: rwMousePoint,
-              originalCenter: e.center,
-              dragEnd: rwMousePoint,
-              edit_event_id,
-            })
+        // Prefer the smallest overlapping component so nested/small parts can
+        // be grabbed even when a larger package bounding box contains them.
+        const hit = findSmallestPcbComponentAt(
+          soup,
+          rwMousePoint,
+          10 / transform.a,
+        )
 
-            onCreateEditEvent({
-              edit_event_id,
-              edit_event_type: "edit_pcb_component_location",
-              pcb_edit_event_type: "edit_component_location",
-              pcb_component_id: e.pcb_component_id,
-              original_center: e.center,
-              new_center: e.center,
-              in_progress: true,
-              created_at: Date.now(),
-            })
-
-            setIsMovingComponent(true)
-            break
-          }
-        }
-        if (!foundActiveComponent) {
+        if (!hit) {
           setActivePcbComponent(null)
+          return
         }
 
-        if (foundActiveComponent) {
-          e.preventDefault()
-          return false
-        }
+        cancelPanDrag()
+        setActivePcbComponent(hit.pcb_component_id)
+        const edit_event_id = Math.random().toString()
+        setDragState({
+          dragStart: rwMousePoint,
+          originalCenter: hit.center,
+          dragEnd: rwMousePoint,
+          edit_event_id,
+        })
+
+        onCreateEditEvent({
+          edit_event_id,
+          edit_event_type: "edit_pcb_component_location",
+          pcb_edit_event_type: "edit_component_location",
+          pcb_component_id: hit.pcb_component_id,
+          original_center: hit.center,
+          new_center: hit.center,
+          in_progress: true,
+          created_at: Date.now(),
+        })
+
+        setIsMovingComponent(true)
+        e.preventDefault()
+        return false
       }}
       onMouseMove={(e) => {
         if (!activePcbComponentId || !dragState) return

--- a/src/lib/find-smallest-pcb-component-at.ts
+++ b/src/lib/find-smallest-pcb-component-at.ts
@@ -1,0 +1,44 @@
+import type { AnyCircuitElement, PcbComponent } from "circuit-json"
+
+export const isInsideOfPcbComponent = (
+  pcb_component: PcbComponent,
+  point: { x: number; y: number },
+  padding = 0,
+) => {
+  const halfWidth = pcb_component.width / 2
+  const halfHeight = pcb_component.height / 2
+
+  const left = pcb_component.center.x - halfWidth - padding
+  const right = pcb_component.center.x + halfWidth + padding
+  const top = pcb_component.center.y - halfHeight - padding
+  const bottom = pcb_component.center.y + halfHeight + padding
+
+  return point.x > left && point.x < right && point.y > top && point.y < bottom
+}
+
+/**
+ * When multiple pcb_components overlap the click point, prefer the one with
+ * the smallest bounding-box area so small parts nested under larger packages
+ * can still be grabbed.
+ */
+export const findSmallestPcbComponentAt = (
+  soup: AnyCircuitElement[],
+  point: { x: number; y: number },
+  padding = 0,
+): PcbComponent | null => {
+  let best: PcbComponent | null = null
+  let bestArea = Number.POSITIVE_INFINITY
+
+  for (const element of soup) {
+    if (element.type !== "pcb_component") continue
+    if (!isInsideOfPcbComponent(element, point, padding)) continue
+
+    const area = element.width * element.height
+    if (area < bestArea) {
+      bestArea = area
+      best = element
+    }
+  }
+
+  return best
+}

--- a/tests/lib/find-smallest-pcb-component-at.test.ts
+++ b/tests/lib/find-smallest-pcb-component-at.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test"
+import type { PcbComponent } from "circuit-json"
+import { findSmallestPcbComponentAt } from "../../src/lib/find-smallest-pcb-component-at"
+
+const pcb = (
+  id: string,
+  center: { x: number; y: number },
+  width: number,
+  height: number,
+): PcbComponent =>
+  ({
+    type: "pcb_component",
+    pcb_component_id: id,
+    center,
+    width,
+    height,
+    layer: "top",
+    rotation: 0,
+    source_component_id: `source_${id}`,
+  }) as PcbComponent
+
+describe("findSmallestPcbComponentAt", () => {
+  test("returns null when nothing is under the point", () => {
+    const soup = [pcb("big", { x: 0, y: 0 }, 10, 10)]
+    expect(findSmallestPcbComponentAt(soup, { x: 100, y: 100 })).toBeNull()
+  })
+
+  test("returns the only component under the point", () => {
+    const soup = [pcb("only", { x: 0, y: 0 }, 4, 2)]
+    expect(
+      findSmallestPcbComponentAt(soup, { x: 0, y: 0 })?.pcb_component_id,
+    ).toBe("only")
+  })
+
+  test("prefers the smallest overlapping component even if a larger one appears first", () => {
+    const soup = [
+      pcb("board_chip", { x: 0, y: 0 }, 20, 20),
+      pcb("tiny_cap", { x: 1, y: 1 }, 1, 1),
+      pcb("medium", { x: 0.5, y: 0.5 }, 4, 4),
+    ]
+
+    expect(
+      findSmallestPcbComponentAt(soup, { x: 1, y: 1 })?.pcb_component_id,
+    ).toBe("tiny_cap")
+  })
+
+  test("respects padding when deciding hits", () => {
+    const soup = [pcb("edge", { x: 0, y: 0 }, 2, 2)]
+    expect(findSmallestPcbComponentAt(soup, { x: 1.4, y: 0 }, 0)).toBeNull()
+    expect(
+      findSmallestPcbComponentAt(soup, { x: 1.4, y: 0 }, 0.5)?.pcb_component_id,
+    ).toBe("edge")
+  })
+})


### PR DESCRIPTION
## Summary
When multiple `pcb_component`s overlap under the cursor in Move Components mode, the picker previously took the first match in soup order. Nested or small parts sitting inside a larger package bounding box were often impossible to grab.

This prefers the hit with the **smallest bounding-box area**, matching #39 / #52.

## Changes
- Add `findSmallestPcbComponentAt` helper
- Use it in `EditPlacementOverlay` click hit-testing
- Unit tests for overlap preference and padding

## Test plan
- [x] `bun test tests/lib/find-smallest-pcb-component-at.test.ts`
- [x] `bun test tests/lib/`
- [x] `bun run build`
- [ ] Manual: Move Components on a board with a small part overlapping a larger package — click the overlap and confirm the small part is selected

Closes #39
Closes #52