### PR TITLE
Add maxWidth style to ToolbarOverlay component

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "@tscircuit/pcb-viewer",

--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -536,7 +536,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
               style={{
                 display: "flex",
                 alignItems: "center",
-                maxWidth: "550px"
+                maxWidth: "550px",
                 gap: "4px",
               }}
             >

--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -536,7 +536,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
               style={{
                 display: "flex",
                 alignItems: "center",
-                maxWidth: "550px",
+                maxWidth: "450px",
                 gap: "4px",
               }}
             >

--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -536,6 +536,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
               style={{
                 display: "flex",
                 alignItems: "center",
+                maxWidth: "550px"
                 gap: "4px",
               }}
             >

--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -430,6 +430,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
           color: "red",
           display: "flex",
           flexWrap: "wrap",
+          maxWidth: "550px",
           gap: 4,
           fontSize: 12,
           fontFamily: "sans-serif",
@@ -536,7 +537,6 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
               style={{
                 display: "flex",
                 alignItems: "center",
-                maxWidth: "450px",
                 gap: "4px",
               }}
             >


### PR DESCRIPTION
motivation: on click the view the drop down slides to the second row in split screen

Before: 

<img width="728" height="276" alt="image" src="https://github.com/user-attachments/assets/dd29eda5-a0d3-4f32-b788-862ac0dedc7e" />

<img width="619" height="460" alt="image" src="https://github.com/user-attachments/assets/dfe14370-d4aa-4e43-a953-834ddc110d01" />



After: 
<img width="628" height="340" alt="image" src="https://github.com/user-attachments/assets/83048226-143e-4d61-92ad-e1771ef0a5f6" />

<img width="627" height="459" alt="image" src="https://github.com/user-attachments/assets/e6d5c322-e6a8-4fe6-92e4-30e3bb2cf3e3" />

