### PR TITLE
Clip viewer traces at visible copper pour boundaries

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@tscircuit/math-utils": "^0.0.36",
         "@vitejs/plugin-react": "^5.0.2",
         "circuit-json": "^0.0.450",
-        "circuit-to-canvas": "^0.0.115",
+        "circuit-to-canvas": "^0.0.118",
         "color": "^4.2.3",
         "react-supergrid": "^1.0.10",
         "react-toastify": "^10.0.5",
@@ -642,7 +642,7 @@
 
     "circuit-json-to-spice": ["circuit-json-to-spice@0.0.34", "", { "dependencies": { "circuit-json-to-connectivity-map": "^0.0.22" }, "peerDependencies": { "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "typescript": "^5.0.0" } }, "sha512-59XyRHATq455875XlEiAfycIvxkOjaKnX4nzzlvY88UJyFcjkHSQCB9HCnbHJGsRxVBEmrTcELLyVIFmB+c4LA=="],
 
-    "circuit-to-canvas": ["circuit-to-canvas@0.0.115", "", { "dependencies": { "transformation-matrix": "^3.1.0" }, "peerDependencies": { "@tscircuit/alphabet": "*", "typescript": "^5" } }, "sha512-sAZ6hy1xynvy9PjAyRANhJjHqmRAU/mBuDkPBI7nQOf2jVdpZIKvB159LMQX8bWWWPKGJKlTLvYifnGSYe+xew=="],
+    "circuit-to-canvas": ["circuit-to-canvas@0.0.118", "", { "dependencies": { "transformation-matrix": "^3.1.0" }, "peerDependencies": { "@tscircuit/alphabet": "*", "typescript": "^5" } }, "sha512-JdLnaq/ToVOaAkCibk60qMFH5fatNuNpRiS6kVC5gbjn9KWQntii17jYmTCNYILYS/ye71HxzCEdeJY/kETyPg=="],
 
     "circuit-to-svg": ["circuit-to-svg@0.0.337", "", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "calculate-elbow": "0.0.12", "debug": "^4.4.3", "svg-path-commander": "^2.1.11", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" }, "peerDependencies": { "@tscircuit/alphabet": "*" } }, "sha512-wNuAGSJVkd/M3BH0u+uBw+dUIowUDF05UwfvxkkmMzmj90y6nQ+bE3QSZLJ+ODua7jtwjzuT5g4r0fMNtDvAuQ=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@tscircuit/math-utils": "^0.0.36",
     "@vitejs/plugin-react": "^5.0.2",
     "circuit-json": "^0.0.450",
-    "circuit-to-canvas": "^0.0.115",
+    "circuit-to-canvas": "^0.0.118",
     "color": "^4.2.3",
     "react-supergrid": "^1.0.10",
     "react-toastify": "^10.0.5",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@tscircuit/math-utils": "^0.0.36",
     "@vitejs/plugin-react": "^5.0.2",
     "circuit-json": "^0.0.450",
-    "circuit-to-canvas": "^0.0.114",
+    "circuit-to-canvas": "^0.0.115",
     "color": "^4.2.3",
     "react-supergrid": "^1.0.10",
     "react-toastify": "^10.0.5",

--- a/src/lib/draw-pcb-trace.ts
+++ b/src/lib/draw-pcb-trace.ts
@@ -114,13 +114,21 @@ export function drawPcbTraceElementsForLayer({
   if (nonHighlightedElements.length > 0) {
     const drawer = new CircuitToCanvasDrawer(canvas)
     drawer.realToCanvasMat = realToCanvasMat
-    drawer.drawElements(nonHighlightedElements, { layers })
+    drawer.drawElements(nonHighlightedElements, {
+      layers,
+      clipTracesInsideSameNetPours: true,
+      clipContextElements: elements,
+    })
   }
 
   if (highlightedElements.length > 0) {
     const highlightDrawer = new CircuitToCanvasDrawer(canvas)
     highlightDrawer.configure({ colorOverrides: HOVER_COLOR_MAP })
     highlightDrawer.realToCanvasMat = realToCanvasMat
-    highlightDrawer.drawElements(highlightedElements, { layers })
+    highlightDrawer.drawElements(highlightedElements, {
+      layers,
+      clipTracesInsideSameNetPours: true,
+      clipContextElements: elements,
+    })
   }
 }

--- a/src/lib/draw-pcb-trace.ts
+++ b/src/lib/draw-pcb-trace.ts
@@ -86,6 +86,11 @@ export const showTraceSegmentsInsideHiddenCopperPours = (
   }),
 })
 
+export const getTraceClipContextElements = (
+  elements: AnyCircuitElement[],
+  showCopperPours: boolean,
+): AnyCircuitElement[] => (showCopperPours ? elements : [])
+
 export function drawPcbTraceElementsForLayer({
   canvas,
   elements,
@@ -135,13 +140,20 @@ export function drawPcbTraceElementsForLayer({
     }
   }
 
+  // The trace renderer receives a filtered element list. Give it the full
+  // circuit only as clipping context while pours are visible; an empty list
+  // deliberately disables geometric clipping when pours are hidden.
+  const clipContextElements = getTraceClipContextElements(
+    elements,
+    showCopperPours,
+  )
+
   if (nonHighlightedElements.length > 0) {
     const drawer = new CircuitToCanvasDrawer(canvas)
     drawer.realToCanvasMat = realToCanvasMat
     drawer.drawElements(nonHighlightedElements, {
       layers,
-      clipTracesInsideSameNetPours: true,
-      clipContextElements: elements,
+      clipContextElements,
     })
   }
 
@@ -151,8 +163,7 @@ export function drawPcbTraceElementsForLayer({
     highlightDrawer.realToCanvasMat = realToCanvasMat
     highlightDrawer.drawElements(highlightedElements, {
       layers,
-      clipTracesInsideSameNetPours: true,
-      clipContextElements: elements,
+      clipContextElements,
     })
   }
 }

--- a/tests/lib/draw-pcb-trace.test.ts
+++ b/tests/lib/draw-pcb-trace.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "bun:test"
-import type { PcbTrace } from "circuit-json"
+import type { AnyCircuitElement, PcbTrace } from "circuit-json"
 import {
   filterTraceByLayers,
+  getTraceClipContextElements,
   showTraceSegmentsInsideHiddenCopperPours,
 } from "../../src/lib/draw-pcb-trace"
 
@@ -106,5 +107,17 @@ describe("drawPcbTrace layer filtering", () => {
     }
     expect(trace.route[0]).toHaveProperty("is_inside_copper_pour", true)
     expect(trace.route[1]).toHaveProperty("is_inside_copper_pour", true)
+  })
+
+  it("disables geometric pour clipping when copper pours are hidden", () => {
+    const elements = [
+      {
+        type: "pcb_copper_pour",
+        pcb_copper_pour_id: "pcb_copper_pour_0",
+      },
+    ] as AnyCircuitElement[]
+
+    expect(getTraceClipContextElements(elements, true)).toBe(elements)
+    expect(getTraceClipContextElements(elements, false)).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary
- bump circuit-to-canvas to 0.0.118
- pass full circuit JSON as clipping-only context for both normal and highlighted trace passes
- use exact finalized pour geometry, so clearance rings and BRep holes remain visible
- disable geometric clipping when copper pours are hidden, preserving the behavior added in #936
- merge current main to resolve the dependency conflict

The clipping work remains on a temporary canvas layer and does not redraw pours or add per-trace SVG-style geometry.

## Verification
- bun test (26 pass)
- bun run build
- bun run format:check

Depends on tscircuit/circuit-to-canvas#267, now merged and published in 0.0.118.