### PR TITLE
Update README to remove CodeSandbox link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/@tscircuit%2Fpcb-viewer.svg)](https://badge.fury.io/js/@tscircuit%2Fpcb-viewer)
 
-[Examples](https://pcb-viewer.vercel.app/) &middot; [TSCircuit](https://tscircuit.com) &middot; [Open in CodeSandbox](https://codesandbox.io/p/github/tscircuit/pcb-viewer)
+[Examples](https://pcb-viewer.vercel.app/) &middot; [TSCircuit](https://tscircuit.com)
 
 Render Printed Circuit Boards w/ React
 


### PR DESCRIPTION
https://codesandbox.io/p/github/tscircuit/pcb-viewer no longer works, 


<img width="751" height="267" alt="image" src="https://github.com/user-attachments/assets/58a4d71c-af7a-47df-b4b9-7c4d2c8082c5" />
