### PR TITLE
fix: show traces when copper pours are hidden

### DIFF
--- a/src/components/CanvasPrimitiveRenderer.tsx
+++ b/src/components/CanvasPrimitiveRenderer.tsx
@@ -49,6 +49,7 @@ export const CanvasPrimitiveRenderer = ({
 }: Props) => {
   const canvasRefs = useRef<Record<string, HTMLCanvasElement>>({})
   const selectedLayer = useGlobalStore((s) => s.selected_layer)
+  const isShowingCopperPours = useGlobalStore((s) => s.is_showing_copper_pours)
   const isShowingSolderMask = useGlobalStore((s) => s.is_showing_solder_mask)
   const isShowingFabricationNotes = useGlobalStore(
     (s) => s.is_showing_fabrication_notes,
@@ -116,6 +117,7 @@ export const CanvasPrimitiveRenderer = ({
           layers: [copperLayer],
           realToCanvasMat: transform,
           primitives,
+          showCopperPours: isShowingCopperPours,
         })
       }
 
@@ -369,6 +371,7 @@ export const CanvasPrimitiveRenderer = ({
     elements,
     transform,
     selectedLayer,
+    isShowingCopperPours,
     isShowingSolderMask,
     isShowingFabricationNotes,
     isShowingCourtyards,

--- a/src/lib/draw-pcb-trace.ts
+++ b/src/lib/draw-pcb-trace.ts
@@ -67,18 +67,39 @@ export const filterTraceByLayers = (
   }
 }
 
+export const showTraceSegmentsInsideHiddenCopperPours = (
+  trace: PcbTrace,
+): PcbTrace => ({
+  ...trace,
+  route: trace.route.map((routePoint) => {
+    if (
+      !("is_inside_copper_pour" in routePoint) ||
+      routePoint.is_inside_copper_pour !== true
+    ) {
+      return routePoint
+    }
+
+    return {
+      ...routePoint,
+      is_inside_copper_pour: false,
+    }
+  }),
+})
+
 export function drawPcbTraceElementsForLayer({
   canvas,
   elements,
   layers,
   realToCanvasMat,
   primitives,
+  showCopperPours,
 }: {
   canvas: HTMLCanvasElement
   elements: AnyCircuitElement[]
   layers: PcbRenderLayer[]
   realToCanvasMat: Matrix
   primitives?: Primitive[]
+  showCopperPours: boolean
 }) {
   const targetLayers = new Set(normalizeCopperRenderLayers(layers))
 
@@ -86,6 +107,9 @@ export function drawPcbTraceElementsForLayer({
     .filter(isPcbTrace)
     .map((trace) => filterTraceByLayers(trace, targetLayers))
     .filter((trace): trace is PcbTrace => trace !== null)
+    .map((trace) =>
+      showCopperPours ? trace : showTraceSegmentsInsideHiddenCopperPours(trace),
+    )
 
   if (traceElements.length === 0) return
 

--- a/tests/lib/draw-pcb-trace.test.ts
+++ b/tests/lib/draw-pcb-trace.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test"
 import type { PcbTrace } from "circuit-json"
-import { filterTraceByLayers } from "../../src/lib/draw-pcb-trace"
+import {
+  filterTraceByLayers,
+  showTraceSegmentsInsideHiddenCopperPours,
+} from "../../src/lib/draw-pcb-trace"
 
 describe("drawPcbTrace layer filtering", () => {
   it("keeps via separators so cross-layer runs do not get stitched together", () => {
@@ -65,5 +68,47 @@ describe("drawPcbTrace layer filtering", () => {
     } as PcbTrace
 
     expect(filterTraceByLayers(trace, new Set(["top"]))).toBeNull()
+  })
+
+  it("shows trace segments marked inside a copper pour when pours are hidden", () => {
+    const trace: PcbTrace = {
+      type: "pcb_trace",
+      pcb_trace_id: "trace_inside_hidden_pour",
+      route: [
+        {
+          route_type: "wire",
+          x: 0,
+          y: 0,
+          width: 0.15,
+          layer: "top",
+          copper_pour_id: "pcb_copper_pour_0",
+          is_inside_copper_pour: true,
+        },
+        {
+          route_type: "wire",
+          x: 1,
+          y: 0,
+          width: 0.15,
+          layer: "top",
+          copper_pour_id: "pcb_copper_pour_0",
+          is_inside_copper_pour: true,
+        },
+      ],
+    }
+
+    const visibleTrace = showTraceSegmentsInsideHiddenCopperPours(trace)
+
+    expect(visibleTrace.route).toEqual([
+      {
+        ...trace.route[0],
+        is_inside_copper_pour: false,
+      },
+      {
+        ...trace.route[1],
+        is_inside_copper_pour: false,
+      },
+    ])
+    expect(trace.route[0]).toHaveProperty("is_inside_copper_pour", true)
+    expect(trace.route[1]).toHaveProperty("is_inside_copper_pour", true)
   })
 })

--- a/tests/lib/draw-pcb-trace.test.ts
+++ b/tests/lib/draw-pcb-trace.test.ts
@@ -98,16 +98,12 @@ describe("drawPcbTrace layer filtering", () => {
 
     const visibleTrace = showTraceSegmentsInsideHiddenCopperPours(trace)
 
-    expect(visibleTrace.route).toEqual([
-      {
-        ...trace.route[0],
-        is_inside_copper_pour: false,
-      },
-      {
-        ...trace.route[1],
-        is_inside_copper_pour: false,
-      },
-    ])
+    for (const routePoint of visibleTrace.route) {
+      if (routePoint.route_type !== "wire") {
+        throw new Error("Expected a wire route point")
+      }
+      expect(routePoint.is_inside_copper_pour).toBe(false)
+    }
     expect(trace.route[0]).toHaveProperty("is_inside_copper_pour", true)
     expect(trace.route[1]).toHaveProperty("is_inside_copper_pour", true)
   })


### PR DESCRIPTION
## Before

When the copper pour is disabled from the menu, it should show the trace

<img width="2252" height="1366" alt="image" src="https://github.com/user-attachments/assets/f080a58d-33eb-4938-9264-46a940debadd" />


## After 
<img width="2160" height="1294" alt="image" src="https://github.com/user-attachments/assets/4aa39284-dbff-41fd-bef8-269d0eec4407" />


## Summary

- pass the copper-pour visibility state into PCB trace rendering
- render a non-mutating trace copy with `is_inside_copper_pour` disabled when pours are hidden
- add a focused unit regression test

## Root cause

The viewer removed `pcb_copper_pour` elements when “Show Copper Pours” was disabled, but the trace route points retained `is_inside_copper_pour: true`. `circuit-to-canvas` therefore continued suppressing those segments even though the pour that visually replaced them was no longer rendered.

## Impact

Turning off copper pours now reveals the complete routed trace while preserving the original Circuit JSON and the existing clipped appearance when pours remain visible.

## Validation

- `tsc --noEmit`
- `bun test` — 25 passed
- `bun run build`
- `bun run format:check`
