### PR TITLE
test: add hidden copper pour trace repro

### DIFF
--- a/src/examples/2026/repros/copper-pour-inside-pour/hidden-copper-pour-shows-complete-trace.fixture.tsx
+++ b/src/examples/2026/repros/copper-pour-inside-pour/hidden-copper-pour-shows-complete-trace.fixture.tsx
@@ -1,0 +1,16 @@
+import React from "react"
+import { PCBViewer } from "../../../../PCBViewer"
+import circuitJson from "./copper-pour-same-net-trace-fully-covered.json"
+
+export const HiddenCopperPourShowsCompleteTrace: React.FC = () => {
+  return (
+    <div style={{ backgroundColor: "black" }}>
+      <PCBViewer
+        circuitJson={circuitJson as any}
+        initialState={{ is_showing_copper_pours: false }}
+      />
+    </div>
+  )
+}
+
+export default HiddenCopperPourShowsCompleteTrace


### PR DESCRIPTION
## Summary

Adds a single React Cosmos fixture that loads the existing fully-covered same-net copper-pour Circuit JSON with `is_showing_copper_pours: false`.

## Issue demonstrated

On current `main`, the copper pour is hidden but the trace segments marked `is_inside_copper_pour: true` remain suppressed. The fixture therefore exposes the missing trace even though “Show Copper Pours” is disabled.

This PR intentionally contains only the repro example and no implementation fix.

## Validation

- `tsc --noEmit`
- `bun run format:check`
- `bun run cosmos-export`
