### PR TITLE
Add PCB notes visibility toggle

### DIFF
--- a/src/components/CanvasPrimitiveRenderer.tsx
+++ b/src/components/CanvasPrimitiveRenderer.tsx
@@ -54,6 +54,7 @@ export const CanvasPrimitiveRenderer = ({
   const isShowingFabricationNotes = useGlobalStore(
     (s) => s.is_showing_fabrication_notes,
   )
+  const isShowingPcbNotes = useGlobalStore((s) => s.is_showing_pcb_notes)
   const isShowingCourtyards = useGlobalStore((s) => s.is_showing_courtyards)
   const isShowingSilkscreen = useGlobalStore((s) => s.is_showing_silkscreen)
 
@@ -272,26 +273,28 @@ export const CanvasPrimitiveRenderer = ({
         }
       }
 
-      // Draw bottom notes
-      const bottomNotesCanvas = canvasRefs.current.bottom_notes
-      if (bottomNotesCanvas) {
-        drawPcbNoteElementsForLayer({
-          canvas: bottomNotesCanvas,
-          elements,
-          layers: ["bottom_user_note"],
-          realToCanvasMat: transform,
-        })
-      }
+      if (isShowingPcbNotes) {
+        // Draw bottom notes
+        const bottomNotesCanvas = canvasRefs.current.bottom_notes
+        if (bottomNotesCanvas) {
+          drawPcbNoteElementsForLayer({
+            canvas: bottomNotesCanvas,
+            elements,
+            layers: ["bottom_user_note"],
+            realToCanvasMat: transform,
+          })
+        }
 
-      // Draw top notes
-      const topNotesCanvas = canvasRefs.current.top_notes
-      if (topNotesCanvas) {
-        drawPcbNoteElementsForLayer({
-          canvas: topNotesCanvas,
-          elements,
-          layers: ["top_user_note"],
-          realToCanvasMat: transform,
-        })
+        // Draw top notes
+        const topNotesCanvas = canvasRefs.current.top_notes
+        if (topNotesCanvas) {
+          drawPcbNoteElementsForLayer({
+            canvas: topNotesCanvas,
+            elements,
+            layers: ["top_user_note"],
+            realToCanvasMat: transform,
+          })
+        }
       }
 
       // Draw top courtyard
@@ -374,6 +377,7 @@ export const CanvasPrimitiveRenderer = ({
     isShowingCopperPours,
     isShowingSolderMask,
     isShowingFabricationNotes,
+    isShowingPcbNotes,
     isShowingCourtyards,
     isShowingSilkscreen,
   ])

--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -156,6 +156,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     setIsShowingSolderMask,
     setIsShowingSilkscreen,
     setIsShowingFabricationNotes,
+    setIsShowingPcbNotes,
     setPcbGroupViewMode,
     setHoveredErrorId,
     setFocusedErrorId,
@@ -180,6 +181,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
       is_showing_solder_mask: s.is_showing_solder_mask,
       is_showing_silkscreen: s.is_showing_silkscreen,
       is_showing_fabrication_notes: s.is_showing_fabrication_notes,
+      is_showing_pcb_notes: s.is_showing_pcb_notes,
       pcb_group_view_mode: s.pcb_group_view_mode,
     },
     setEditMode: s.setEditMode,
@@ -194,6 +196,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     setIsShowingSolderMask: s.setIsShowingSolderMask,
     setIsShowingSilkscreen: s.setIsShowingSilkscreen,
     setIsShowingFabricationNotes: s.setIsShowingFabricationNotes,
+    setIsShowingPcbNotes: s.setIsShowingPcbNotes,
     setPcbGroupViewMode: s.setPcbGroupViewMode,
     setHoveredErrorId: s.setHoveredErrorId,
     setFocusedErrorId: s.setFocusedErrorId,
@@ -616,6 +619,13 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
                     setIsShowingFabricationNotes(
                       !viewSettings.is_showing_fabrication_notes,
                     )
+                  }}
+                />
+                <CheckboxMenuItem
+                  label="Show PCB Notes"
+                  checked={viewSettings.is_showing_pcb_notes}
+                  onClick={() => {
+                    setIsShowingPcbNotes(!viewSettings.is_showing_pcb_notes)
                   }}
                 />
                 <CheckboxMenuItem

--- a/src/global-store.ts
+++ b/src/global-store.ts
@@ -36,6 +36,7 @@ export interface State {
   is_showing_solder_mask: boolean
   is_showing_silkscreen: boolean
   is_showing_fabrication_notes: boolean
+  is_showing_pcb_notes: boolean
   pcb_group_view_mode: "all" | "named_only"
 
   hovered_error_id: string | null
@@ -57,6 +58,7 @@ export interface State {
   setIsShowingSolderMask: (is_showing: boolean) => void
   setIsShowingSilkscreen: (is_showing: boolean) => void
   setIsShowingFabricationNotes: (is_showing: boolean) => void
+  setIsShowingPcbNotes: (is_showing: boolean) => void
   setPcbGroupViewMode: (mode: "all" | "named_only") => void
   setHoveredErrorId: (errorId: string | null) => void
   setFocusedErrorId: (errorId: string | null) => void
@@ -118,6 +120,10 @@ export const createStore = (
         is_showing_fabrication_notes: getStoredBoolean(
           STORAGE_KEYS.IS_SHOWING_FABRICATION_NOTES,
           false,
+        ),
+        is_showing_pcb_notes: getStoredBoolean(
+          STORAGE_KEYS.IS_SHOWING_PCB_NOTES,
+          true,
         ),
         pcb_group_view_mode: disablePcbGroups
           ? "all"
@@ -187,6 +193,10 @@ export const createStore = (
             is_showing,
           )
           set({ is_showing_fabrication_notes: is_showing })
+        },
+        setIsShowingPcbNotes: (is_showing) => {
+          setStoredBoolean(STORAGE_KEYS.IS_SHOWING_PCB_NOTES, is_showing)
+          set({ is_showing_pcb_notes: is_showing })
         },
         setPcbGroupViewMode: (mode) => {
           if (disablePcbGroups) return

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -8,6 +8,7 @@ export const STORAGE_KEYS = {
   IS_SHOWING_GROUP_ANCHOR_OFFSETS: "pcb_viewer_is_showing_group_anchor_offsets",
   IS_SHOWING_SOLDER_MASK: "pcb_viewer_is_showing_solder_mask",
   IS_SHOWING_FABRICATION_NOTES: "pcb_viewer_is_showing_fabrication_notes",
+  IS_SHOWING_PCB_NOTES: "pcb_viewer_is_showing_pcb_notes",
   IS_SHOWING_SILKSCREEN: "pcb_viewer_is_showing_silkscreen",
 } as const
 

--- a/tests/global-store.test.ts
+++ b/tests/global-store.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test"
+import { createStore } from "../src/global-store"
+
+test("PCB notes are shown by default and can be hidden", () => {
+  const store = createStore()
+
+  expect(store.getState().is_showing_pcb_notes).toBe(true)
+
+  store.getState().setIsShowingPcbNotes(false)
+
+  expect(store.getState().is_showing_pcb_notes).toBe(false)
+})


### PR DESCRIPTION
## Summary

- add a **Show PCB Notes** checkbox to the View menu
- keep PCB notes visible by default while allowing users to hide them
- persist the visibility preference in local storage
- gate top and bottom PCB note rendering on the preference
- add a regression test for the default and toggled state

## Why

PCB notes were always rendered, so users could not remove them from the board view when they obscured other PCB details.

## User impact

PCB notes continue to appear by default. Users can now uncheck **Show PCB Notes** in the View menu to hide them, and the viewer remembers that choice.

## Validation

- `bun test` (27 passing)
- `bun run build`
- `bun run format:check`
- `git diff --check`