### PR TITLE
Show layer-aware PCB trace names on hover

### DIFF
--- a/src/components/CanvasElementsRenderer.tsx
+++ b/src/components/CanvasElementsRenderer.tsx
@@ -1,25 +1,26 @@
+import type { ManualEditEvent } from "@tscircuit/props"
 import type { AnyCircuitElement } from "circuit-json"
 import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import type { GraphicsObject } from "graphics-debug"
+import { convertElementToPrimitives } from "lib/convert-element-to-primitive"
 import type { GridConfig, Primitive } from "lib/types"
 import { addInteractionMetadataToPrimitives } from "lib/util/addInteractionMetadataToPrimitives"
-import { findErrorElementById, getErrorId } from "lib/util/get-error-id"
 import {
   buildErrorPreviewElementIndexes,
   createTransformForBounds,
   getErrorPreviewBounds,
   getRelatedIdsForError,
 } from "lib/util/error-preview"
+import { findErrorElementById, getErrorId } from "lib/util/get-error-id"
 import {
   animateTransform,
   cancelTransformAnimation,
 } from "lib/util/transform-animation"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
-import { type Matrix } from "transformation-matrix"
-import { convertElementToPrimitives } from "lib/convert-element-to-primitive"
+import type { Matrix } from "transformation-matrix"
+import { useGlobalStore } from "../global-store"
 import { CanvasPrimitiveRenderer } from "./CanvasPrimitiveRenderer"
 import { DebugGraphicsOverlay } from "./DebugGraphicsOverlay"
-import { WarningGraphicsOverlay } from "./WarningGraphicsOverlay"
 import { type BoundsSelection, DimensionOverlay } from "./DimensionOverlay"
 import { EditPlacementOverlay } from "./EditPlacementOverlay"
 import { EditTraceHintOverlay } from "./EditTraceHintOverlay"
@@ -28,8 +29,7 @@ import { MouseElementTracker } from "./MouseElementTracker"
 import { PcbGroupOverlay } from "./PcbGroupOverlay"
 import { RatsNestOverlay } from "./RatsNestOverlay"
 import { ToolbarOverlay } from "./ToolbarOverlay"
-import type { ManualEditEvent } from "@tscircuit/props"
-import { useGlobalStore } from "../global-store"
+import { WarningGraphicsOverlay } from "./WarningGraphicsOverlay"
 
 export interface CanvasElementsRendererProps {
   elements: AnyCircuitElement[]
@@ -49,12 +49,17 @@ export interface CanvasElementsRendererProps {
 
 export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
   const { transform, elements } = props
-  const { hoveredErrorId, focusedErrorId, isShowingCopperPours } =
-    useGlobalStore((state) => ({
-      hoveredErrorId: state.hovered_error_id,
-      focusedErrorId: state.focused_error_id,
-      isShowingCopperPours: state.is_showing_copper_pours,
-    }))
+  const {
+    hoveredErrorId,
+    focusedErrorId,
+    isShowingCopperPours,
+    selectedLayer,
+  } = useGlobalStore((state) => ({
+    hoveredErrorId: state.hovered_error_id,
+    focusedErrorId: state.focused_error_id,
+    isShowingCopperPours: state.is_showing_copper_pours,
+    selectedLayer: state.selected_layer,
+  }))
   const activeErrorId = focusedErrorId ?? hoveredErrorId
 
   const elementsToRender = useMemo(
@@ -232,6 +237,7 @@ export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
       elements={elementsToRender}
       transform={transform}
       primitives={primitivesWithoutInteractionMetadata}
+      selectedLayer={selectedLayer}
       onMouseHoverOverPrimitives={onMouseOverPrimitives}
     >
       <EditPlacementOverlay

--- a/src/components/CanvasPrimitiveRenderer.tsx
+++ b/src/components/CanvasPrimitiveRenderer.tsx
@@ -1,6 +1,12 @@
 import type { AnyCircuitElement, PcbRenderLayer } from "circuit-json"
 import { Drawer } from "lib/Drawer"
+import {
+  getCopperLayerRefsFromElements,
+  getCopperRenderLayer,
+  getOrderedCanvasLayers,
+} from "lib/copper-layers"
 import { drawCopperPourElementsForLayer } from "lib/draw-copper-pour"
+import { drawCourtyardElementsForLayer } from "lib/draw-courtyard"
 import { drawFabricationNoteElementsForLayer } from "lib/draw-fabrication-note"
 import { drawGrid } from "lib/draw-grid"
 import { drawPcbHoleElementsForLayer } from "lib/draw-hole"
@@ -14,15 +20,9 @@ import { drawPcbSmtPadElementsForLayer } from "lib/draw-pcb-smtpad"
 import { drawPcbTraceElementsForLayer } from "lib/draw-pcb-trace"
 import { drawPlatedHolePads } from "lib/draw-plated-hole"
 import { drawPrimitives } from "lib/draw-primitives"
-import { drawSoldermaskElementsForLayer } from "lib/draw-soldermask"
 import { drawSilkscreenElementsForLayer } from "lib/draw-silkscreen"
+import { drawSoldermaskElementsForLayer } from "lib/draw-soldermask"
 import { drawPcbViaElementsForLayer } from "lib/draw-via"
-import { drawCourtyardElementsForLayer } from "lib/draw-courtyard"
-import {
-  getCopperLayerRefsFromElements,
-  getCopperRenderLayer,
-  getOrderedCanvasLayers,
-} from "lib/copper-layers"
 import type { GridConfig, Primitive } from "lib/types"
 import React, { useEffect, useRef } from "react"
 import { SuperGrid, toMMSI } from "react-supergrid"
@@ -116,6 +116,7 @@ export const CanvasPrimitiveRenderer = ({
           canvas,
           elements,
           layers: [copperLayer],
+          selectedLayer,
           realToCanvasMat: transform,
           primitives,
           showCopperPours: isShowingCopperPours,

--- a/src/components/ElementOverlayBox.tsx
+++ b/src/components/ElementOverlayBox.tsx
@@ -1,14 +1,14 @@
-import React, { useEffect, useState } from "react"
-import type { HighlightedPrimitive } from "./MouseElementTracker"
-import { useGlobalStore } from "../global-store"
-import { zIndexMap } from "lib/util/z-index-map"
 import type {
   AnyCircuitElement,
   PcbPlatedHoleOval,
   PcbSmtPadRotatedPill,
 } from "circuit-json"
-import { getTraceOverlayInfo } from "lib/get-trace-overlay-text"
 import { filterTracesIfMultiple } from "lib/filter-traces-if-multiple"
+import { getTraceOverlayInfo } from "lib/get-trace-overlay-text"
+import { zIndexMap } from "lib/util/z-index-map"
+import React, { useEffect, useState } from "react"
+import { useGlobalStore } from "../global-store"
+import type { HighlightedPrimitive } from "./MouseElementTracker"
 
 const containerStyle = {
   position: "absolute",
@@ -177,7 +177,18 @@ export const HighlightedPrimitiveBoxWithText = ({
             whiteSpace: "nowrap",
           }}
         >
-          {overlayInfo.text}
+          {overlayInfo.text && <div>{overlayInfo.text}</div>}
+          {overlayInfo.name && (
+            <div
+              style={{
+                fontSize: "11px",
+                lineHeight: 1.2,
+                marginTop: overlayInfo.text ? "2px" : 0,
+              }}
+            >
+              {overlayInfo.name}
+            </div>
+          )}
         </div>
       </div>
     )
@@ -278,9 +289,9 @@ export const ElementOverlayBox = ({
   return (
     <div style={containerStyle}>
       {!is_moving_component &&
-        primitives.map((primitive, i) => (
+        primitives.map((primitive) => (
           <HighlightedPrimitiveBoxWithText
-            key={i}
+            key={primitive._pcb_drawing_object_id}
             primitive={primitive}
             mousePos={mousePos}
             elements={elements}

--- a/src/components/MouseElementTracker.tsx
+++ b/src/components/MouseElementTracker.tsx
@@ -1,10 +1,10 @@
 import { pointToSegmentDistance } from "@tscircuit/math-utils"
-import type { AnyCircuitElement } from "circuit-json"
+import type { AnyCircuitElement, LayerRef } from "circuit-json"
 import { distance } from "circuit-json"
 import type { Primitive } from "lib/types"
 import { ifSetsMatchExactly } from "lib/util/if-sets-match-exactly"
 import type React from "react"
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useMeasure } from "react-use"
 import type { Matrix } from "transformation-matrix"
 import { applyToPoint, inverse } from "transformation-matrix"
@@ -68,15 +68,22 @@ const isPointInsidePolygon = (
   return isInside
 }
 
-const getPrimitivesUnderPoint = (
+export const getPrimitivesUnderPoint = (
   primitives: Primitive[],
   rwPoint: { x: number; y: number },
   transform: Matrix,
+  selectedLayer: LayerRef,
 ): Primitive[] => {
   const newMousedPrimitives: Primitive[] = []
 
   for (const primitive of primitives) {
     if (!primitive._element) continue
+    if (
+      primitive._element.type === "pcb_trace" &&
+      primitive.layer !== selectedLayer
+    ) {
+      continue
+    }
 
     // Handle PCB traces
     if ("x1" in primitive && primitive._element?.type === "pcb_trace") {
@@ -176,17 +183,24 @@ export const MouseElementTracker = ({
   children,
   transform,
   primitives,
+  selectedLayer,
   onMouseHoverOverPrimitives,
 }: {
   elements: AnyCircuitElement[]
   children: React.ReactNode
   transform?: Matrix
   primitives: Primitive[]
+  selectedLayer: LayerRef
   onMouseHoverOverPrimitives: (primitivesHoveredOver: Primitive[]) => void
 }) => {
   const [mousedPrimitives, setMousedPrimitives] = useState<Primitive[]>([])
   const [mousePos, setMousePos] = useState({ x: 0, y: 0 })
   const [containerRef, { width, height }] = useMeasure<HTMLDivElement>()
+
+  useEffect(() => {
+    setMousedPrimitives([])
+    onMouseHoverOverPrimitives([])
+  }, [selectedLayer, onMouseHoverOverPrimitives])
 
   const highlightedPrimitives = useMemo(() => {
     const highlightedPrimitives: HighlightedPrimitive[] = []
@@ -291,6 +305,7 @@ export const MouseElementTracker = ({
       primitives,
       rwPoint,
       transform,
+      selectedLayer,
     )
 
     if (

--- a/src/components/MouseElementTracker.tsx
+++ b/src/components/MouseElementTracker.tsx
@@ -3,17 +3,18 @@ import type { AnyCircuitElement } from "circuit-json"
 import { distance } from "circuit-json"
 import type { Primitive } from "lib/types"
 import { ifSetsMatchExactly } from "lib/util/if-sets-match-exactly"
-import React, { useState, useMemo } from "react"
+import type React from "react"
+import { useMemo, useState } from "react"
 import { useMeasure } from "react-use"
 import type { Matrix } from "transformation-matrix"
 import { applyToPoint, inverse } from "transformation-matrix"
-import { ElementOverlayBox } from "./ElementOverlayBox"
 import {
   BoardAnchorOffsetOverlay,
-  GroupAnchorOffsetOverlay,
   ComponentBoundingBoxOverlay,
+  GroupAnchorOffsetOverlay,
   PanelAnchorOffsetOverlay,
 } from "./AnchorOffsetOverlay"
+import { ElementOverlayBox } from "./ElementOverlayBox"
 
 const getPolygonBoundingBox = (
   points: ReadonlyArray<{ x: number; y: number }>,
@@ -216,6 +217,13 @@ export const MouseElementTracker = ({
         basePoint = boundingBox.center
         w = boundingBox.width
         h = boundingBox.height
+      } else if (primitive.pcb_drawing_type === "line") {
+        basePoint = {
+          x: (primitive.x1 + primitive.x2) / 2,
+          y: (primitive.y1 + primitive.y2) / 2,
+        }
+        w = Math.abs(primitive.x2 - primitive.x1)
+        h = Math.abs(primitive.y2 - primitive.y1)
       } else if ("x" in primitive && "y" in primitive) {
         basePoint = { x: primitive.x, y: primitive.y }
         w =
@@ -363,6 +371,7 @@ export const MouseElementTracker = ({
 }
 
 export type HighlightedPrimitive = {
+  _pcb_drawing_object_id: string
   x: number
   y: number
   w: number

--- a/src/lib/draw-pcb-trace.ts
+++ b/src/lib/draw-pcb-trace.ts
@@ -1,4 +1,9 @@
-import type { AnyCircuitElement, PcbRenderLayer, PcbTrace } from "circuit-json"
+import type {
+  AnyCircuitElement,
+  LayerRef,
+  PcbRenderLayer,
+  PcbTrace,
+} from "circuit-json"
 import {
   CircuitToCanvasDrawer,
   DEFAULT_PCB_COLOR_MAP,
@@ -7,8 +12,8 @@ import {
 import color from "color"
 import type { Matrix } from "transformation-matrix"
 import colors from "./colors"
-import type { Primitive } from "./types"
 import { normalizeCopperRenderLayers } from "./copper-layers"
+import type { Primitive } from "./types"
 
 // Color map with lighter copper colors for hover effect
 const HOVER_COLOR_MAP: PcbColorMap = {
@@ -91,10 +96,35 @@ export const getTraceClipContextElements = (
   showCopperPours: boolean,
 ): AnyCircuitElement[] => (showCopperPours ? elements : [])
 
+export const getHighlightedTraceElementIds = ({
+  primitives,
+  targetLayers,
+  selectedLayer,
+}: {
+  primitives: Primitive[]
+  targetLayers: Set<string>
+  selectedLayer: LayerRef
+}): Set<string> => {
+  const highlightedElementIds = new Set<string>()
+  if (!targetLayers.has(selectedLayer)) return highlightedElementIds
+
+  for (const primitive of primitives) {
+    if (
+      (primitive.is_mouse_over || primitive.is_in_highlighted_net) &&
+      primitive._element?.type === "pcb_trace"
+    ) {
+      highlightedElementIds.add(primitive._element.pcb_trace_id)
+    }
+  }
+
+  return highlightedElementIds
+}
+
 export function drawPcbTraceElementsForLayer({
   canvas,
   elements,
   layers,
+  selectedLayer,
   realToCanvasMat,
   primitives,
   showCopperPours,
@@ -102,6 +132,7 @@ export function drawPcbTraceElementsForLayer({
   canvas: HTMLCanvasElement
   elements: AnyCircuitElement[]
   layers: PcbRenderLayer[]
+  selectedLayer: LayerRef
   realToCanvasMat: Matrix
   primitives?: Primitive[]
   showCopperPours: boolean
@@ -118,17 +149,11 @@ export function drawPcbTraceElementsForLayer({
 
   if (traceElements.length === 0) return
 
-  const highlightedElementIds = new Set<string>()
-  if (primitives) {
-    for (const primitive of primitives) {
-      if (
-        (primitive.is_mouse_over || primitive.is_in_highlighted_net) &&
-        primitive._element?.type === "pcb_trace"
-      ) {
-        highlightedElementIds.add(primitive._element.pcb_trace_id)
-      }
-    }
-  }
+  const highlightedElementIds = getHighlightedTraceElementIds({
+    primitives: primitives ?? [],
+    targetLayers,
+    selectedLayer,
+  })
 
   const highlightedElements: PcbTrace[] = []
   const nonHighlightedElements: PcbTrace[] = []

--- a/src/lib/filter-traces-if-multiple.ts
+++ b/src/lib/filter-traces-if-multiple.ts
@@ -1,5 +1,6 @@
-import { AnyCircuitElement } from "circuit-json"
-import { HighlightedPrimitive } from "../components/MouseElementTracker"
+import type { AnyCircuitElement } from "circuit-json"
+import type { HighlightedPrimitive } from "../components/MouseElementTracker"
+import { getAssociatedTraceName } from "./get-trace-overlay-text"
 
 export function filterTracesIfMultiple(filterTraces: {
   primitives: HighlightedPrimitive[]
@@ -27,20 +28,28 @@ export function filterTracesIfMultiple(filterTraces: {
   // Get non-trace primitives
   const nonTraces = primitives.filter((p) => p._element.type !== "pcb_trace")
 
-  // Find traces that have corresponding source traces with max_length
-  const tracesWithMaxLength = traces.filter((trace) =>
-    sourceTraces.some(
+  // Named traces and nets should always have a hover label, even when the
+  // viewer is configured to hide ordinary trace-length overlays.
+  const tracesWithPersistentOverlay = traces.filter((trace) => {
+    const hasMaxLength = sourceTraces.some(
       (sourceTrace) =>
-        trace._element.type === "pcb_trace" &&
         trace._element.source_trace_id === sourceTrace.source_trace_id &&
         sourceTrace.max_length !== undefined,
-    ),
-  )
+    )
 
-  // If not showing multiple traces length, return non-traces and traces with
-  // max length
+    return (
+      hasMaxLength ||
+      getAssociatedTraceName({
+        primitiveElement: trace._element,
+        elements,
+      }) !== null
+    )
+  })
+
+  // If not showing multiple trace lengths, keep only overlays that carry
+  // important metadata (a configured max length or a source name).
   if (!is_showing_multiple_traces_length) {
-    return [...nonTraces, ...tracesWithMaxLength]
+    return [...nonTraces, ...tracesWithPersistentOverlay]
   }
 
   // If multiple traces exist, return only the shortest one

--- a/src/lib/get-trace-overlay-text.ts
+++ b/src/lib/get-trace-overlay-text.ts
@@ -1,14 +1,44 @@
 import { su } from "@tscircuit/circuit-json-util"
-import { AnyCircuitElement } from "circuit-json"
+import type { AnyCircuitElement, PcbTrace } from "circuit-json"
 
 interface TraceTextContext {
-  primitiveElement: any
+  primitiveElement: PcbTrace
   elements: AnyCircuitElement[]
 }
 
 interface TraceOverlayInfo {
   text: string
+  name: string | null
   isOverLength: boolean
+}
+
+const getNonEmptyName = (name?: string) => name?.trim() || null
+
+export function getAssociatedTraceName({
+  primitiveElement,
+  elements,
+}: TraceTextContext): string | null {
+  const sourceElementId = primitiveElement.source_trace_id
+  if (!sourceElementId) return null
+
+  const circuitJson = su(elements)
+  const sourceTrace = circuitJson.source_trace.get(sourceElementId)
+
+  const sourceTraceName = getNonEmptyName(sourceTrace?.name)
+  if (sourceTraceName) return sourceTraceName
+
+  const sourceNet = circuitJson.source_net.get(sourceElementId)
+  const sourceNetName = getNonEmptyName(sourceNet?.name)
+  if (sourceNetName) return sourceNetName
+
+  for (const sourceNetId of sourceTrace?.connected_source_net_ids ?? []) {
+    const connectedSourceNetName = getNonEmptyName(
+      circuitJson.source_net.get(sourceNetId)?.name,
+    )
+    if (connectedSourceNetName) return connectedSourceNetName
+  }
+
+  return null
 }
 
 export function getTraceOverlayInfo({
@@ -22,6 +52,7 @@ export function getTraceOverlayInfo({
   const trace = su(elements).source_trace.get(
     primitiveElement?.source_trace_id!,
   )
+  const name = getAssociatedTraceName({ primitiveElement, elements })
   // Get connection information
   if (trace?.display_name) {
     // Add max length info
@@ -33,15 +64,17 @@ export function getTraceOverlayInfo({
     text += `(${trace.display_name})`
   }
 
-  if (!text) return null
+  if (!text && !name) return null
 
-  const isOverLength =
+  const isOverLength = Boolean(
     primitiveElement.trace_length &&
-    trace?.max_length &&
-    primitiveElement.trace_length > trace.max_length
+      trace?.max_length &&
+      primitiveElement.trace_length > trace.max_length,
+  )
 
   return {
     text,
+    name,
     isOverLength,
   }
 }

--- a/tests/lib/draw-pcb-trace.test.ts
+++ b/tests/lib/draw-pcb-trace.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test"
 import type { AnyCircuitElement, PcbTrace } from "circuit-json"
 import {
   filterTraceByLayers,
+  getHighlightedTraceElementIds,
   getTraceClipContextElements,
   showTraceSegmentsInsideHiddenCopperPours,
 } from "../../src/lib/draw-pcb-trace"
@@ -119,5 +120,40 @@ describe("drawPcbTrace layer filtering", () => {
 
     expect(getTraceClipContextElements(elements, true)).toBe(elements)
     expect(getTraceClipContextElements(elements, false)).toEqual([])
+  })
+
+  it("only highlights traces on the selected layer", () => {
+    const trace: PcbTrace = {
+      type: "pcb_trace",
+      pcb_trace_id: "trace1",
+      route: [],
+    }
+    const highlightedPrimitive = {
+      _pcb_drawing_object_id: "line_0",
+      _element: trace,
+      pcb_drawing_type: "line",
+      x1: 0,
+      y1: 0,
+      x2: 1,
+      y2: 0,
+      width: 0.15,
+      layer: "top",
+      is_mouse_over: true,
+    } as const
+
+    expect(
+      getHighlightedTraceElementIds({
+        primitives: [highlightedPrimitive],
+        targetLayers: new Set(["top"]),
+        selectedLayer: "top",
+      }),
+    ).toEqual(new Set(["trace1"]))
+    expect(
+      getHighlightedTraceElementIds({
+        primitives: [highlightedPrimitive],
+        targetLayers: new Set(["bottom"]),
+        selectedLayer: "top",
+      }),
+    ).toEqual(new Set())
   })
 })

--- a/tests/lib/filter-traces-if-multiple.test.ts
+++ b/tests/lib/filter-traces-if-multiple.test.ts
@@ -1,0 +1,33 @@
+import { expect, it } from "bun:test"
+import type { AnyCircuitElement, PcbTrace } from "circuit-json"
+import type { HighlightedPrimitive } from "../../src/components/MouseElementTracker"
+import { filterTracesIfMultiple } from "../../src/lib/filter-traces-if-multiple"
+
+it("keeps named trace overlays visible when ordinary trace lengths are hidden", () => {
+  const pcbTrace: PcbTrace = {
+    type: "pcb_trace",
+    pcb_trace_id: "pcb_trace_0",
+    source_trace_id: "source_net_0",
+    route: [],
+  }
+  const elements = [
+    pcbTrace,
+    {
+      type: "source_net",
+      source_net_id: "source_net_0",
+      name: "GND",
+      member_source_group_ids: [],
+    },
+  ] as AnyCircuitElement[]
+  const primitive = {
+    _element: pcbTrace,
+  } as HighlightedPrimitive
+
+  expect(
+    filterTracesIfMultiple({
+      primitives: [primitive],
+      is_showing_multiple_traces_length: false,
+      elements,
+    }),
+  ).toEqual([primitive])
+})

--- a/tests/lib/get-trace-overlay-text.test.ts
+++ b/tests/lib/get-trace-overlay-text.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test"
+import type { AnyCircuitElement, PcbTrace } from "circuit-json"
+import {
+  getAssociatedTraceName,
+  getTraceOverlayInfo,
+} from "../../src/lib/get-trace-overlay-text"
+
+const createPcbTrace = (sourceTraceId?: string): PcbTrace => ({
+  type: "pcb_trace",
+  pcb_trace_id: "pcb_trace_0",
+  source_trace_id: sourceTraceId,
+  route: [],
+})
+
+describe("trace hover labels", () => {
+  it("uses the name of an associated source net", () => {
+    const pcbTrace = createPcbTrace("source_net_0")
+    const elements = [
+      pcbTrace,
+      {
+        type: "source_net",
+        source_net_id: "source_net_0",
+        name: "GND",
+        member_source_group_ids: [],
+      },
+    ] as AnyCircuitElement[]
+
+    expect(
+      getTraceOverlayInfo({ primitiveElement: pcbTrace, elements }),
+    ).toEqual({ text: "", name: "GND", isOverLength: false })
+  })
+
+  it("uses the name of an associated source trace", () => {
+    const pcbTrace = createPcbTrace("source_trace_0")
+    const elements = [
+      pcbTrace,
+      {
+        type: "source_trace",
+        source_trace_id: "source_trace_0",
+        connected_source_port_ids: [],
+        connected_source_net_ids: [],
+        name: "clock",
+      },
+    ] as AnyCircuitElement[]
+
+    expect(
+      getAssociatedTraceName({ primitiveElement: pcbTrace, elements }),
+    ).toBe("clock")
+  })
+
+  it("falls back to the name of a source trace's connected net", () => {
+    const pcbTrace = createPcbTrace("source_trace_0")
+    const elements = [
+      pcbTrace,
+      {
+        type: "source_trace",
+        source_trace_id: "source_trace_0",
+        connected_source_port_ids: [],
+        connected_source_net_ids: ["source_net_0"],
+      },
+      {
+        type: "source_net",
+        source_net_id: "source_net_0",
+        name: "VCC",
+        member_source_group_ids: [],
+      },
+    ] as AnyCircuitElement[]
+
+    expect(
+      getAssociatedTraceName({ primitiveElement: pcbTrace, elements }),
+    ).toBe("VCC")
+  })
+
+  it("does not create an overlay for a trace without hover text", () => {
+    const pcbTrace = createPcbTrace()
+
+    expect(
+      getTraceOverlayInfo({ primitiveElement: pcbTrace, elements: [pcbTrace] }),
+    ).toBeNull()
+  })
+})

--- a/tests/lib/mouse-element-tracker.test.ts
+++ b/tests/lib/mouse-element-tracker.test.ts
@@ -1,0 +1,36 @@
+import { expect, it } from "bun:test"
+import type { PcbTrace } from "circuit-json"
+import { getPrimitivesUnderPoint } from "../../src/components/MouseElementTracker"
+import type { Line } from "../../src/lib/types"
+
+const trace: PcbTrace = {
+  type: "pcb_trace",
+  pcb_trace_id: "trace_0",
+  route: [],
+}
+
+const createTracePrimitive = (layer: "top" | "bottom"): Line => ({
+  _pcb_drawing_object_id: `line_${layer}`,
+  _element: trace,
+  pcb_drawing_type: "line",
+  x1: 0,
+  y1: 0,
+  x2: 1,
+  y2: 0,
+  width: 0.15,
+  layer,
+})
+
+it("only hit-tests PCB traces on the selected layer", () => {
+  const topTrace = createTracePrimitive("top")
+  const bottomTrace = createTracePrimitive("bottom")
+
+  expect(
+    getPrimitivesUnderPoint(
+      [topTrace, bottomTrace],
+      { x: 0.5, y: 0 },
+      { a: 40, b: 0, c: 0, d: 40, e: 0, f: 0 },
+      "top",
+    ),
+  ).toEqual([topTrace])
+})


### PR DESCRIPTION
## Summary

- resolve hover labels from `source_trace.name`, directly associated `source_net.name`, or a connected source net
- render the resolved name as compact text in the existing cursor tooltip
- keep named trace overlays visible when ordinary trace-length overlays are hidden
- support line primitives in the highlighted-trace overlay path
- limit trace hit-testing and canvas highlighting to the selected copper layer
- clear stale trace hover state when the selected layer changes
- add focused resolver, filtering, hit-testing, and layer-rendering tests

## Why

PCB trace hover text previously depended on trace-length metadata and `source_trace.display_name`. Named source nets and explicitly named source traces were not resolved, and ordinary traces were filtered out when the “Show All Trace Lengths” setting was disabled. Constant-width line traces were also hit-tested but dropped before overlay rendering.

Trace interactions additionally considered overlapping traces from every copper layer. Once a connected trace was marked, the renderer reused that highlight on every layer canvas instead of constraining it to the selected layer.

## Impact

Hovering a PCB trace now shows its meaningful source trace or net name at the cursor without requiring trace-length overlays to be enabled. When layers overlap, only traces on the selected copper layer can be hovered or highlighted.

## Validation

- `bun test` — 34 tests passed
- `bun run build`
- `bunx biome check` on all changed source and test files
- `git diff --check`
