### PR TITLE
Fix trace hover tooltip labels and positioning

### DIFF
--- a/src/components/ElementOverlayBox.tsx
+++ b/src/components/ElementOverlayBox.tsx
@@ -148,18 +148,15 @@ export const HighlightedPrimitiveBoxWithText = ({
     const overlayInfo = getTraceOverlayInfo(traceTextContext)
     if (!overlayInfo) return null
 
-    const yOffset = mousePos.y - 35
-
     return (
       <div
         style={{
           zIndex: zIndexMap.elementOverlay,
           position: "absolute",
-          left: mousePos.x,
-          top: yOffset,
+          left: mousePos.x + 12,
+          top: mousePos.y + 12,
           color,
           pointerEvents: "none",
-          transform: "translateX(-50%)",
         }}
       >
         <div
@@ -169,11 +166,11 @@ export const HighlightedPrimitiveBoxWithText = ({
             textShadow: "none",
             WebkitFontSmoothing: "antialiased",
             MozOsxFontSmoothing: "grayscale",
-            padding: "6px 6px",
-            borderRadius: "6px",
-            fontSize: "14px",
-            minWidth: "45px",
-            textAlign: "center",
+            padding: "4px 6px",
+            borderRadius: "4px",
+            fontSize: "11px",
+            lineHeight: 1.2,
+            textAlign: "left",
             whiteSpace: "nowrap",
           }}
         >
@@ -181,8 +178,6 @@ export const HighlightedPrimitiveBoxWithText = ({
           {overlayInfo.name && (
             <div
               style={{
-                fontSize: "11px",
-                lineHeight: 1.2,
                 marginTop: overlayInfo.text ? "2px" : 0,
               }}
             >

--- a/src/lib/get-trace-overlay-text.ts
+++ b/src/lib/get-trace-overlay-text.ts
@@ -45,31 +45,25 @@ export function getTraceOverlayInfo({
   primitiveElement,
   elements,
 }: TraceTextContext): TraceOverlayInfo | null {
-  let text = primitiveElement.trace_length
-    ? `${primitiveElement.trace_length.toFixed(3)}`
-    : ""
-
   const trace = su(elements).source_trace.get(
     primitiveElement?.source_trace_id!,
   )
-  const name = getAssociatedTraceName({ primitiveElement, elements })
-  // Get connection information
-  if (trace?.display_name) {
-    // Add max length info
-    if (trace?.max_length) {
-      text += ` / ${trace.max_length}mm `
-    } else {
-      text += " mm "
-    }
-    text += `(${trace.display_name})`
-  }
+  const traceLength = primitiveElement.trace_length
+  const hasTraceLength = typeof traceLength === "number"
+  const maxLength = trace?.max_length
+  const text = hasTraceLength
+    ? `${traceLength.toFixed(3)}${
+        typeof maxLength === "number" ? ` / ${maxLength}` : ""
+      } mm`
+    : ""
+  const name =
+    getAssociatedTraceName({ primitiveElement, elements }) ??
+    getNonEmptyName(trace?.display_name)
 
   if (!text && !name) return null
 
   const isOverLength = Boolean(
-    primitiveElement.trace_length &&
-      trace?.max_length &&
-      primitiveElement.trace_length > trace.max_length,
+    hasTraceLength && typeof maxLength === "number" && traceLength > maxLength,
   )
 
   return {

--- a/tests/lib/get-trace-overlay-text.test.ts
+++ b/tests/lib/get-trace-overlay-text.test.ts
@@ -30,6 +30,94 @@ describe("trace hover labels", () => {
     ).toEqual({ text: "", name: "GND", isOverLength: false })
   })
 
+  it("prefers a trace name over its pad selector display name", () => {
+    const pcbTrace = {
+      ...createPcbTrace("source_trace_0"),
+      trace_length: 1.25,
+    }
+    const elements = [
+      pcbTrace,
+      {
+        type: "source_trace",
+        source_trace_id: "source_trace_0",
+        connected_source_port_ids: [],
+        connected_source_net_ids: [],
+        name: "clock",
+        display_name: "U1.1 to U2.2",
+      },
+    ] as AnyCircuitElement[]
+
+    expect(
+      getTraceOverlayInfo({ primitiveElement: pcbTrace, elements }),
+    ).toEqual({ text: "1.250 mm", name: "clock", isOverLength: false })
+  })
+
+  it("falls back to the pad selector display name", () => {
+    const pcbTrace = createPcbTrace("source_trace_0")
+    const elements = [
+      pcbTrace,
+      {
+        type: "source_trace",
+        source_trace_id: "source_trace_0",
+        connected_source_port_ids: [],
+        connected_source_net_ids: [],
+        display_name: "U1.1 to U2.2",
+      },
+    ] as AnyCircuitElement[]
+
+    expect(
+      getTraceOverlayInfo({ primitiveElement: pcbTrace, elements }),
+    ).toEqual({
+      text: "",
+      name: "U1.1 to U2.2",
+      isOverLength: false,
+    })
+  })
+
+  it("only includes the unit when a trace length is present", () => {
+    const pcbTrace = createPcbTrace("source_trace_0")
+    const elements = [
+      pcbTrace,
+      {
+        type: "source_trace",
+        source_trace_id: "source_trace_0",
+        connected_source_port_ids: [],
+        connected_source_net_ids: [],
+        max_length: 5,
+        display_name: "U1.1 to U2.2",
+      },
+    ] as AnyCircuitElement[]
+
+    expect(
+      getTraceOverlayInfo({ primitiveElement: pcbTrace, elements }),
+    ).toEqual({
+      text: "",
+      name: "U1.1 to U2.2",
+      isOverLength: false,
+    })
+  })
+
+  it("formats measured and maximum trace lengths together", () => {
+    const pcbTrace = {
+      ...createPcbTrace("source_trace_0"),
+      trace_length: 5.125,
+    }
+    const elements = [
+      pcbTrace,
+      {
+        type: "source_trace",
+        source_trace_id: "source_trace_0",
+        connected_source_port_ids: [],
+        connected_source_net_ids: [],
+        max_length: 5,
+      },
+    ] as AnyCircuitElement[]
+
+    expect(
+      getTraceOverlayInfo({ primitiveElement: pcbTrace, elements }),
+    ).toEqual({ text: "5.125 / 5 mm", name: null, isOverLength: true })
+  })
+
   it("uses the name of an associated source trace", () => {
     const pcbTrace = createPcbTrace("source_trace_0")
     const elements = [


### PR DESCRIPTION
## Summary

- prefer an associated trace or net name over the pad-selector display name
- show `mm` only when a numeric trace length is available, while preserving selector text as a fallback label
- make the trace tooltip smaller and offset it from the cursor
- add regression coverage for label preference, missing lengths, max-length formatting, and over-length state

## Root cause

Trace hover formatting appended the unit and selector-based `display_name` whenever connection information existed, even when `trace_length` was absent. The tooltip was also centered horizontally on the pointer with a 14px font and minimum width, which made it feel oversized and overlap the cursor.

## Impact

Trace hover labels are more readable, named traces are easier to identify, and missing length data no longer produces labels such as `mm (...)`.

## Validation

- `bun test` (38 tests pass)
- `bunx tsc --noEmit --project tsconfig.json`
- `bun run build`
- `bunx biome check src/lib/get-trace-overlay-text.ts src/components/ElementOverlayBox.tsx tests/lib/get-trace-overlay-text.test.ts`