### PR TITLE
Update circuit-to-canvas to 0.0.123

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
         "@tscircuit/math-utils": "^0.0.36",
         "@vitejs/plugin-react": "^5.0.2",
         "circuit-json": "^0.0.450",
-        "circuit-to-canvas": "^0.0.120",
+        "circuit-to-canvas": "^0.0.123",
         "color": "^4.2.3",
         "react-supergrid": "^1.0.10",
         "react-toastify": "^10.0.5",
@@ -642,7 +642,7 @@
 
     "circuit-json-to-spice": ["circuit-json-to-spice@0.0.34", "", { "dependencies": { "circuit-json-to-connectivity-map": "^0.0.22" }, "peerDependencies": { "@tscircuit/circuit-json-util": "*", "circuit-json": "*", "typescript": "^5.0.0" } }, "sha512-59XyRHATq455875XlEiAfycIvxkOjaKnX4nzzlvY88UJyFcjkHSQCB9HCnbHJGsRxVBEmrTcELLyVIFmB+c4LA=="],
 
-    "circuit-to-canvas": ["circuit-to-canvas@0.0.120", "", { "dependencies": { "transformation-matrix": "^3.1.0" }, "peerDependencies": { "@tscircuit/alphabet": "*", "typescript": "^5" } }, "sha512-5J9n6msPVm5kP97Yo84v70wAqMPTn1Xv0Fk1pY7ktw4Aw5lYEXBWy3E1Q8fRt13KapJZFqMOSgax9TItMpjW9A=="],
+    "circuit-to-canvas": ["circuit-to-canvas@0.0.123", "", { "dependencies": { "transformation-matrix": "^3.1.0" }, "peerDependencies": { "@tscircuit/alphabet": "*", "typescript": "^5" } }, "sha512-qRA2RzMc2YnvXoSRSO/2dFJ86KLYJ/kixh76ObmiiiXYT7rV9inwrpGFsg9xlU0RXDIlE/rW3e4djQNikdy8gQ=="],
 
     "circuit-to-svg": ["circuit-to-svg@0.0.337", "", { "dependencies": { "@types/node": "^22.5.5", "bun-types": "^1.1.40", "calculate-elbow": "0.0.12", "debug": "^4.4.3", "svg-path-commander": "^2.1.11", "svgson": "^5.3.1", "transformation-matrix": "^2.16.1" }, "peerDependencies": { "@tscircuit/alphabet": "*" } }, "sha512-wNuAGSJVkd/M3BH0u+uBw+dUIowUDF05UwfvxkkmMzmj90y6nQ+bE3QSZLJ+ODua7jtwjzuT5g4r0fMNtDvAuQ=="],
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@tscircuit/math-utils": "^0.0.36",
     "@vitejs/plugin-react": "^5.0.2",
     "circuit-json": "^0.0.450",
-    "circuit-to-canvas": "^0.0.120",
+    "circuit-to-canvas": "^0.0.123",
     "color": "^4.2.3",
     "react-supergrid": "^1.0.10",
     "react-toastify": "^10.0.5",


### PR DESCRIPTION
## Summary

- update `circuit-to-canvas` to `0.0.123`
- refresh the resolved dependency or generated type bundle where tracked

## Why

Recent canvas-rendering fixes were published to npm, but this consumer was still constrained to an older `0.0.x` release. Because caret ranges for `0.0.x` do not advance to the next patch, the latest fixes were not reaching downstream users.

## Validation

- formatting check passes
- production build passes
- repository tests pass where local platform prerequisites are available
