### PR TITLE
Remove editing controls from the toolbar

### DIFF
--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -167,7 +167,6 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     selectLayer: s.selectLayer,
     editModes: {
       in_move_footprint_mode: s.in_move_footprint_mode,
-      in_draw_trace_mode: s.in_draw_trace_mode,
     },
     viewSettings: {
       is_showing_rats_nest: s.is_showing_rats_nest,
@@ -338,10 +337,6 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     setErrorsOpen(false)
   }, [])
 
-  const handleEditTraceToggle = useCallback(() => {
-    setEditMode(editModes.in_draw_trace_mode ? "off" : "draw_trace")
-  }, [editModes.in_draw_trace_mode, setEditMode])
-
   const handleMoveComponentToggle = useCallback(() => {
     setEditMode(editModes.in_move_footprint_mode ? "off" : "move_footprint")
   }, [editModes.in_move_footprint_mode, setEditMode])
@@ -484,16 +479,6 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
           setHoveredErrorId={setHoveredErrorId}
           setFocusedErrorId={setFocusedErrorId}
         />
-        <ToolbarButton
-          isSmallScreen={isSmallScreen}
-          style={{}}
-          onClick={handleEditTraceToggle}
-        >
-          <div>
-            {editModes.in_draw_trace_mode ? "✖ " : ""}
-            Edit Traces
-          </div>
-        </ToolbarButton>
         <ToolbarButton
           isSmallScreen={isSmallScreen}
           style={{}}

--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -142,9 +142,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     setIsMouseOverContainer,
     selectedLayer,
     selectLayer,
-    editModes,
     viewSettings,
-    setEditMode,
     setIsShowingRatsNest,
     setIsShowingMultipleTracesLength,
     setIsShowingAutorouting,
@@ -165,9 +163,6 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     setIsMouseOverContainer: s.setIsMouseOverContainer,
     selectedLayer: s.selected_layer,
     selectLayer: s.selectLayer,
-    editModes: {
-      in_move_footprint_mode: s.in_move_footprint_mode,
-    },
     viewSettings: {
       is_showing_rats_nest: s.is_showing_rats_nest,
       is_showing_multiple_traces_length: s.is_showing_multiple_traces_length,
@@ -183,7 +178,6 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
       is_showing_pcb_notes: s.is_showing_pcb_notes,
       pcb_group_view_mode: s.pcb_group_view_mode,
     },
-    setEditMode: s.setEditMode,
     setIsShowingRatsNest: s.setIsShowingRatsNest,
     setIsShowingMultipleTracesLength: s.setIsShowingMultipleTracesLength,
     setIsShowingAutorouting: s.setIsShowingAutorouting,
@@ -337,10 +331,6 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     setErrorsOpen(false)
   }, [])
 
-  const handleMoveComponentToggle = useCallback(() => {
-    setEditMode(editModes.in_move_footprint_mode ? "off" : "move_footprint")
-  }, [editModes.in_move_footprint_mode, setEditMode])
-
   const handleRatsNestToggle = useCallback(() => {
     setIsShowingRatsNest(!viewSettings.is_showing_rats_nest)
   }, [viewSettings.is_showing_rats_nest, setIsShowingRatsNest])
@@ -479,16 +469,6 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
           setHoveredErrorId={setHoveredErrorId}
           setFocusedErrorId={setFocusedErrorId}
         />
-        <ToolbarButton
-          isSmallScreen={isSmallScreen}
-          style={{}}
-          onClick={handleMoveComponentToggle}
-        >
-          <div>
-            {editModes.in_move_footprint_mode ? "✖ " : ""}
-            Move Components
-          </div>
-        </ToolbarButton>
         <ToolbarButton
           isSmallScreen={isSmallScreen}
           style={{}}


### PR DESCRIPTION
## Summary

- remove the **Edit Traces** button from the PCB viewer toolbar
- remove the **Move Components** button from the PCB viewer toolbar
- remove the toolbar-only edit-mode subscriptions and toggle callbacks
- preserve the underlying trace and component editing implementations for other consumers

## Impact

The PCB viewer toolbar no longer exposes the Edit Traces or Move Components actions. Other toolbar controls and the underlying editing internals are unchanged.

## Validation

- `bun test` (38 tests passed)
- `bun run build`
- `bun run format:check`
- `git diff --check`