### PR TITLE
Highlight hovered traces across all layers

### DIFF
--- a/src/components/CanvasPrimitiveRenderer.tsx
+++ b/src/components/CanvasPrimitiveRenderer.tsx
@@ -116,7 +116,6 @@ export const CanvasPrimitiveRenderer = ({
           canvas,
           elements,
           layers: [copperLayer],
-          selectedLayer,
           realToCanvasMat: transform,
           primitives,
           showCopperPours: isShowingCopperPours,

--- a/src/lib/draw-pcb-trace.ts
+++ b/src/lib/draw-pcb-trace.ts
@@ -1,9 +1,4 @@
-import type {
-  AnyCircuitElement,
-  LayerRef,
-  PcbRenderLayer,
-  PcbTrace,
-} from "circuit-json"
+import type { AnyCircuitElement, PcbRenderLayer, PcbTrace } from "circuit-json"
 import {
   CircuitToCanvasDrawer,
   DEFAULT_PCB_COLOR_MAP,
@@ -98,15 +93,10 @@ export const getTraceClipContextElements = (
 
 export const getHighlightedTraceElementIds = ({
   primitives,
-  targetLayers,
-  selectedLayer,
 }: {
   primitives: Primitive[]
-  targetLayers: Set<string>
-  selectedLayer: LayerRef
 }): Set<string> => {
   const highlightedElementIds = new Set<string>()
-  if (!targetLayers.has(selectedLayer)) return highlightedElementIds
 
   for (const primitive of primitives) {
     if (
@@ -124,7 +114,6 @@ export function drawPcbTraceElementsForLayer({
   canvas,
   elements,
   layers,
-  selectedLayer,
   realToCanvasMat,
   primitives,
   showCopperPours,
@@ -132,7 +121,6 @@ export function drawPcbTraceElementsForLayer({
   canvas: HTMLCanvasElement
   elements: AnyCircuitElement[]
   layers: PcbRenderLayer[]
-  selectedLayer: LayerRef
   realToCanvasMat: Matrix
   primitives?: Primitive[]
   showCopperPours: boolean
@@ -151,8 +139,6 @@ export function drawPcbTraceElementsForLayer({
 
   const highlightedElementIds = getHighlightedTraceElementIds({
     primitives: primitives ?? [],
-    targetLayers,
-    selectedLayer,
   })
 
   const highlightedElements: PcbTrace[] = []

--- a/tests/lib/draw-pcb-trace.test.ts
+++ b/tests/lib/draw-pcb-trace.test.ts
@@ -122,7 +122,7 @@ describe("drawPcbTrace layer filtering", () => {
     expect(getTraceClipContextElements(elements, false)).toEqual([])
   })
 
-  it("only highlights traces on the selected layer", () => {
+  it("highlights a hovered trace on every rendered copper layer", () => {
     const trace: PcbTrace = {
       type: "pcb_trace",
       pcb_trace_id: "trace1",
@@ -144,16 +144,7 @@ describe("drawPcbTrace layer filtering", () => {
     expect(
       getHighlightedTraceElementIds({
         primitives: [highlightedPrimitive],
-        targetLayers: new Set(["top"]),
-        selectedLayer: "top",
       }),
     ).toEqual(new Set(["trace1"]))
-    expect(
-      getHighlightedTraceElementIds({
-        primitives: [highlightedPrimitive],
-        targetLayers: new Set(["bottom"]),
-        selectedLayer: "top",
-      }),
-    ).toEqual(new Set())
   })
 })


### PR DESCRIPTION
## What changed

- highlight every routed segment of a hovered PCB trace across all copper layers
- preserve selected-layer-only hit testing so traces on background layers do not intercept hover
- continue using the existing lightened copper hover colors
- update the trace highlight regression test for cross-layer behavior

## Root cause

Each copper layer renders the same hovered trace independently, but the highlight helper discarded the trace ID whenever the canvas layer was not the selected layer. That restricted the whiteish hover treatment to one layer.

## Impact

Hovering any visible segment now makes the entire trace easy to follow through vias and layer changes.

## Validation

- `bun test` — 38 passed
- `bun run build`
- `bun run format:check`
- `git diff --check`