### PR TITLE
Add controlled PCB component focus requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ The PCBViewer component accepts these props:
 - `editEvents`: Array of edit events to apply
 - `onEditEventsChanged`: Callback when edit events change
 - `onBoundsSelected`: Callback when the Bounds tool completes a rectangle selection. Receives `{ minX, minY, maxX, maxY }`.
+- `pcbComponentFocusRequest`: Controlled `{ pcbComponentId, requestId }` request that smoothly focuses a complete component footprint. Increment `requestId` to focus the same component again.
 - `initialState`: Initial state for the viewer
 
 ### Features

--- a/src/PCBViewer.tsx
+++ b/src/PCBViewer.tsx
@@ -17,6 +17,7 @@ import { calculateCircuitJsonKey } from "lib/calculate-circuit-json-key"
 import { calculateBoardSizeKey } from "lib/calculate-board-size-key"
 import {
   getPcbComponentFocusTarget,
+  isPcbComponentFocusAppliedToCircuit,
   shouldHandlePcbComponentFocusRequest,
   shouldResetBoardTransform,
   type PcbComponentFocusRequest,
@@ -88,7 +89,10 @@ export const PCBViewer = ({
   const initialRenderCompleted = useRef(false)
   const previousBoardSizeKeyRef = useRef(boardSizeKey)
   const lastHandledFocusRequestIdRef = useRef<number | null>(null)
-  const lastAppliedFocusRequestIdRef = useRef<number | null>(null)
+  const lastAppliedFocusRequestRef = useRef<{
+    requestId: number
+    circuitJsonKey: string
+  } | null>(null)
   const touchStartRef = useRef<{ x: number; y: number } | null>(null)
   const circuitJsonKey = useMemo(
     () => calculateCircuitJsonKey(circuitJson),
@@ -136,16 +140,13 @@ export const PCBViewer = ({
     })
   }, [pcbElmsPreEdit, editEvents])
 
-  const pcbComponentFocusTarget = useMemo(
-    () =>
-      pcbComponentFocusRequest
-        ? getPcbComponentFocusTarget(
-            elements,
-            pcbComponentFocusRequest.pcbComponentId,
-          )
-        : null,
-    [elements, pcbComponentFocusRequest],
-  )
+  const pcbComponentFocusTarget = useMemo(() => {
+    if (!pcbComponentFocusRequest) return null
+    return getPcbComponentFocusTarget(
+      elements,
+      pcbComponentFocusRequest.pcbComponentId,
+    )
+  }, [elements, pcbComponentFocusRequest])
   const shouldHandleFocusRequest = shouldHandlePcbComponentFocusRequest(
     pcbComponentFocusRequest,
     lastHandledFocusRequestIdRef.current,
@@ -154,8 +155,11 @@ export const PCBViewer = ({
     pcbComponentFocusTarget &&
       pcbComponentFocusRequest &&
       (shouldHandleFocusRequest ||
-        lastAppliedFocusRequestIdRef.current ===
-          pcbComponentFocusRequest.requestId),
+        isPcbComponentFocusAppliedToCircuit({
+          request: pcbComponentFocusRequest,
+          appliedRequest: lastAppliedFocusRequestRef.current,
+          circuitJsonKey,
+        })),
   )
 
   useEffect(() => {
@@ -186,12 +190,19 @@ export const PCBViewer = ({
     (requestId: number, applied: boolean) => {
       lastHandledFocusRequestIdRef.current = requestId
       if (applied) {
-        lastAppliedFocusRequestIdRef.current = requestId
+        lastAppliedFocusRequestRef.current = {
+          requestId,
+          circuitJsonKey,
+        }
         initialRenderCompleted.current = true
       }
     },
-    [],
+    [circuitJsonKey],
   )
+  let pendingPcbComponentFocusRequest: PcbComponentFocusRequest | undefined
+  if (shouldHandleFocusRequest) {
+    pendingPcbComponentFocusRequest = pcbComponentFocusRequest
+  }
 
   const onCreateEditEvent = (event: ManualEditEvent) => {
     setEditEvents([...editEvents, event])
@@ -248,9 +259,7 @@ export const PCBViewer = ({
               },
             }}
             elements={elements as SourceTrace[]}
-            pcbComponentFocusRequest={
-              shouldHandleFocusRequest ? pcbComponentFocusRequest : undefined
-            }
+            pcbComponentFocusRequest={pendingPcbComponentFocusRequest}
             onPcbComponentFocusHandled={handlePcbComponentFocusHandled}
             debugGraphics={debugGraphics}
           />

--- a/src/PCBViewer.tsx
+++ b/src/PCBViewer.tsx
@@ -15,10 +15,18 @@ import type { ManualEditEvent } from "@tscircuit/props"
 import { zIndexMap } from "lib/util/z-index-map"
 import { calculateCircuitJsonKey } from "lib/calculate-circuit-json-key"
 import { calculateBoardSizeKey } from "lib/calculate-board-size-key"
+import {
+  getPcbComponentFocusTarget,
+  shouldHandlePcbComponentFocusRequest,
+  shouldResetBoardTransform,
+  type PcbComponentFocusRequest,
+} from "lib/util/pcb-component-focus"
 
 const defaultTransform = compose(translate(400, 300), scale(40, -40))
 
-type Props = {
+export type { PcbComponentFocusRequest } from "lib/util/pcb-component-focus"
+
+export type PCBViewerProps = {
   circuitJson?: AnyCircuitElement[]
   height?: number
   allowEditing?: boolean
@@ -30,6 +38,7 @@ type Props = {
   clickToInteractEnabled?: boolean
   debugGraphics?: GraphicsObject | null
   disablePcbGroups?: boolean
+  pcbComponentFocusRequest?: PcbComponentFocusRequest
 }
 
 export const PCBViewer = ({
@@ -44,7 +53,8 @@ export const PCBViewer = ({
   focusOnHover = false,
   clickToInteractEnabled = false,
   disablePcbGroups = false,
-}: Props) => {
+  pcbComponentFocusRequest,
+}: PCBViewerProps) => {
   const [isInteractionEnabled, setIsInteractionEnabled] = useState(
     !clickToInteractEnabled,
   )
@@ -74,14 +84,16 @@ export const PCBViewer = ({
   let [editEvents, setEditEvents] = useState<ManualEditEvent[]>([])
   editEvents = editEventsProp ?? editEvents
 
+  const boardSizeKey = calculateBoardSizeKey(circuitJson)
   const initialRenderCompleted = useRef(false)
+  const previousBoardSizeKeyRef = useRef(boardSizeKey)
+  const lastHandledFocusRequestIdRef = useRef<number | null>(null)
+  const lastAppliedFocusRequestIdRef = useRef<number | null>(null)
   const touchStartRef = useRef<{ x: number; y: number } | null>(null)
   const circuitJsonKey = useMemo(
     () => calculateCircuitJsonKey(circuitJson),
     [circuitJson],
   )
-  const boardSizeKey = calculateBoardSizeKey(circuitJson)
-
   const resetTransform = () => {
     const elmBounds =
       refDimensions?.width > 0 ? refDimensions : { width: 500, height: 500 }
@@ -109,23 +121,6 @@ export const PCBViewer = ({
     return
   }
 
-  useEffect(() => {
-    if (!refDimensions?.width) return
-    if (!circuitJson) return
-    if (circuitJson.length === 0) return
-
-    if (!initialRenderCompleted.current) {
-      resetTransform()
-      initialRenderCompleted.current = true
-    }
-  }, [circuitJson, refDimensions])
-
-  useEffect(() => {
-    if (initialRenderCompleted.current === true) {
-      resetTransform()
-    }
-  }, [boardSizeKey])
-
   const pcbElmsPreEdit = useMemo(() => {
     return (
       circuitJson?.filter(
@@ -140,6 +135,63 @@ export const PCBViewer = ({
       editEvents,
     })
   }, [pcbElmsPreEdit, editEvents])
+
+  const pcbComponentFocusTarget = useMemo(
+    () =>
+      pcbComponentFocusRequest
+        ? getPcbComponentFocusTarget(
+            elements,
+            pcbComponentFocusRequest.pcbComponentId,
+          )
+        : null,
+    [elements, pcbComponentFocusRequest],
+  )
+  const shouldHandleFocusRequest = shouldHandlePcbComponentFocusRequest(
+    pcbComponentFocusRequest,
+    lastHandledFocusRequestIdRef.current,
+  )
+  const hasValidFocusRequest = Boolean(
+    pcbComponentFocusTarget &&
+      pcbComponentFocusRequest &&
+      (shouldHandleFocusRequest ||
+        lastAppliedFocusRequestIdRef.current ===
+          pcbComponentFocusRequest.requestId),
+  )
+
+  useEffect(() => {
+    if (!refDimensions.width || !refDimensions.height) return
+    if (!circuitJson?.length) return
+
+    const boardSizeChanged = previousBoardSizeKeyRef.current !== boardSizeKey
+    previousBoardSizeKeyRef.current = boardSizeKey
+    if (
+      shouldResetBoardTransform({
+        initialRenderCompleted: initialRenderCompleted.current,
+        boardSizeChanged,
+        hasValidFocusRequest,
+      })
+    ) {
+      resetTransform()
+      initialRenderCompleted.current = true
+    }
+  }, [
+    boardSizeKey,
+    circuitJson,
+    hasValidFocusRequest,
+    refDimensions.height,
+    refDimensions.width,
+  ])
+
+  const handlePcbComponentFocusHandled = useCallback(
+    (requestId: number, applied: boolean) => {
+      lastHandledFocusRequestIdRef.current = requestId
+      if (applied) {
+        lastAppliedFocusRequestIdRef.current = requestId
+        initialRenderCompleted.current = true
+      }
+    },
+    [],
+  )
 
   const onCreateEditEvent = (event: ManualEditEvent) => {
     setEditEvents([...editEvents, event])
@@ -196,6 +248,10 @@ export const PCBViewer = ({
               },
             }}
             elements={elements as SourceTrace[]}
+            pcbComponentFocusRequest={
+              shouldHandleFocusRequest ? pcbComponentFocusRequest : undefined
+            }
+            onPcbComponentFocusHandled={handlePcbComponentFocusHandled}
             debugGraphics={debugGraphics}
           />
           <ToastContainer />
@@ -205,7 +261,7 @@ export const PCBViewer = ({
         <div
           onClick={() => {
             setIsInteractionEnabled(true)
-            resetTransform()
+            if (!hasValidFocusRequest) resetTransform()
           }}
           onTouchStart={(e) => {
             const touch = e.touches[0]
@@ -225,7 +281,7 @@ export const PCBViewer = ({
             if (deltaX < 10 && deltaY < 10) {
               e.preventDefault()
               setIsInteractionEnabled(true)
-              resetTransform()
+              if (!hasValidFocusRequest) resetTransform()
             }
 
             touchStartRef.current = null

--- a/src/components/CanvasElementsRenderer.tsx
+++ b/src/components/CanvasElementsRenderer.tsx
@@ -21,6 +21,7 @@ import type { Matrix } from "transformation-matrix"
 import {
   createPcbComponentFocusTransform,
   getPcbComponentFocusTarget,
+  shouldHandlePcbComponentFocusRequest,
   type PcbComponentFocusRequest,
 } from "lib/util/pcb-component-focus"
 import { useGlobalStore } from "../global-store"
@@ -96,6 +97,7 @@ export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
   const [hoveredComponentIds, setHoveredComponentIds] = useState<string[]>([])
   const currentTransformRef = useRef<Matrix | null>(transform ?? null)
   const zoomAnimationFrameRef = useRef<number | null>(null)
+  const activePcbComponentFocusRequestIdRef = useRef<number | null>(null)
 
   const elementIndexes = useMemo(
     () => buildErrorPreviewElementIndexes(elements),
@@ -179,7 +181,26 @@ export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
 
   useEffect(() => {
     const request = props.pcbComponentFocusRequest
-    if (!request || !props.width || !props.height || !props.setTransform) return
+    if (!request) {
+      if (activePcbComponentFocusRequestIdRef.current !== null) {
+        cancelTransformAnimation(zoomAnimationFrameRef.current)
+      }
+      activePcbComponentFocusRequestIdRef.current = null
+      return
+    }
+    if (focusedErrorId) {
+      activePcbComponentFocusRequestIdRef.current = null
+      return
+    }
+    if (!props.width || !props.height || !props.setTransform) return
+    if (
+      !shouldHandlePcbComponentFocusRequest(
+        request,
+        activePcbComponentFocusRequestIdRef.current,
+      )
+    ) {
+      return
+    }
 
     const target = getPcbComponentFocusTarget(elements, request.pcbComponentId)
     if (!target) {
@@ -190,6 +211,7 @@ export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
     const startTransform = currentTransformRef.current ?? transform
     if (!startTransform) return
 
+    activePcbComponentFocusRequestIdRef.current = request.requestId
     selectLayer(target.layer)
     const targetTransform = createPcbComponentFocusTransform({
       target,
@@ -198,7 +220,6 @@ export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
     })
 
     cancelTransformAnimation(zoomAnimationFrameRef.current)
-    props.onPcbComponentFocusHandled?.(request.requestId, true)
     animateTransform({
       startTransform,
       endTransform: targetTransform,
@@ -210,9 +231,16 @@ export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
         currentTransformRef.current = nextTransform
         props.setTransform?.(nextTransform)
       },
+      onComplete: () => {
+        if (activePcbComponentFocusRequestIdRef.current !== request.requestId) {
+          return
+        }
+        props.onPcbComponentFocusHandled?.(request.requestId, true)
+      },
     })
   }, [
     elements,
+    focusedErrorId,
     props.height,
     props.onPcbComponentFocusHandled,
     props.pcbComponentFocusRequest,

--- a/src/components/CanvasElementsRenderer.tsx
+++ b/src/components/CanvasElementsRenderer.tsx
@@ -18,6 +18,11 @@ import {
 } from "lib/util/transform-animation"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { Matrix } from "transformation-matrix"
+import {
+  createPcbComponentFocusTransform,
+  getPcbComponentFocusTarget,
+  type PcbComponentFocusRequest,
+} from "lib/util/pcb-component-focus"
 import { useGlobalStore } from "../global-store"
 import { CanvasPrimitiveRenderer } from "./CanvasPrimitiveRenderer"
 import { DebugGraphicsOverlay } from "./DebugGraphicsOverlay"
@@ -44,6 +49,8 @@ export interface CanvasElementsRendererProps {
   cancelPanDrag: () => void
   onCreateEditEvent: (event: ManualEditEvent) => void
   onModifyEditEvent: (event: Partial<ManualEditEvent>) => void
+  pcbComponentFocusRequest?: PcbComponentFocusRequest
+  onPcbComponentFocusHandled?: (requestId: number, applied: boolean) => void
 }
 
 export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
@@ -53,11 +60,13 @@ export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
     focusedErrorId,
     isShowingCopperPours,
     selectedLayer,
+    selectLayer,
   } = useGlobalStore((state) => ({
     hoveredErrorId: state.hovered_error_id,
     focusedErrorId: state.focused_error_id,
     isShowingCopperPours: state.is_showing_copper_pours,
     selectedLayer: state.selected_layer,
+    selectLayer: state.selectLayer,
   }))
   const activeErrorId = focusedErrorId ?? hoveredErrorId
 
@@ -166,6 +175,51 @@ export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
     props.height,
     props.setTransform,
     props.width,
+  ])
+
+  useEffect(() => {
+    const request = props.pcbComponentFocusRequest
+    if (!request || !props.width || !props.height || !props.setTransform) return
+
+    const target = getPcbComponentFocusTarget(elements, request.pcbComponentId)
+    if (!target) {
+      props.onPcbComponentFocusHandled?.(request.requestId, false)
+      return
+    }
+
+    const startTransform = currentTransformRef.current ?? transform
+    if (!startTransform) return
+
+    selectLayer(target.layer)
+    const targetTransform = createPcbComponentFocusTransform({
+      target,
+      width: props.width,
+      height: props.height,
+    })
+
+    cancelTransformAnimation(zoomAnimationFrameRef.current)
+    props.onPcbComponentFocusHandled?.(request.requestId, true)
+    animateTransform({
+      startTransform,
+      endTransform: targetTransform,
+      durationMs: 420,
+      setAnimationFrameId: (animationFrameId) => {
+        zoomAnimationFrameRef.current = animationFrameId
+      },
+      onUpdate: (nextTransform) => {
+        currentTransformRef.current = nextTransform
+        props.setTransform?.(nextTransform)
+      },
+    })
+  }, [
+    elements,
+    props.height,
+    props.onPcbComponentFocusHandled,
+    props.pcbComponentFocusRequest,
+    props.setTransform,
+    props.width,
+    selectLayer,
+    transform,
   ])
 
   const primitives = useMemo(() => {

--- a/src/lib/util/error-preview.ts
+++ b/src/lib/util/error-preview.ts
@@ -382,19 +382,23 @@ export const createTransformForBounds = ({
   bounds,
   width,
   height,
+  padding = 0.7,
+  maxScale = 240,
 }: {
   bounds: Bounds
   width: number
   height: number
+  padding?: number
+  maxScale?: number
 }): Matrix => {
   const center = {
     x: (bounds.minX + bounds.maxX) / 2,
     y: (bounds.minY + bounds.maxY) / 2,
   }
-  const targetWidth = Math.max(bounds.maxX - bounds.minX, 0.8) + 1.4
-  const targetHeight = Math.max(bounds.maxY - bounds.minY, 0.8) + 1.4
+  const targetWidth = Math.max(bounds.maxX - bounds.minX, 0.8) + padding * 2
+  const targetHeight = Math.max(bounds.maxY - bounds.minY, 0.8) + padding * 2
   const scaleFactor =
-    Math.min(width / targetWidth, height / targetHeight, 240) * 0.92
+    Math.min(width / targetWidth, height / targetHeight, maxScale) * 0.92
 
   return compose(
     translate(width / 2, height / 2),

--- a/src/lib/util/pcb-component-focus.ts
+++ b/src/lib/util/pcb-component-focus.ts
@@ -1,0 +1,93 @@
+import { getBoundsOfPcbElements } from "@tscircuit/circuit-json-util"
+import type { AnyCircuitElement, LayerRef, PcbComponent } from "circuit-json"
+import type { Matrix } from "transformation-matrix"
+import { createTransformForBounds } from "./error-preview"
+
+export interface PcbComponentFocusRequest {
+  pcbComponentId: string
+  requestId: number
+}
+
+export interface PcbComponentFocusTarget {
+  component: PcbComponent
+  bounds: {
+    minX: number
+    minY: number
+    maxX: number
+    maxY: number
+  }
+  layer: LayerRef
+}
+
+export const PCB_COMPONENT_FOCUS_PADDING_MM = 1.75
+export const PCB_COMPONENT_FOCUS_MAX_SCALE = 100
+
+const hasFiniteBounds = (bounds: PcbComponentFocusTarget["bounds"]) =>
+  Object.values(bounds).every(Number.isFinite)
+
+export const getPcbComponentFocusTarget = (
+  elements: AnyCircuitElement[],
+  pcbComponentId: string,
+): PcbComponentFocusTarget | null => {
+  const component = elements.find(
+    (element): element is PcbComponent =>
+      element.type === "pcb_component" &&
+      element.pcb_component_id === pcbComponentId,
+  )
+  if (!component) return null
+
+  const footprintElements = elements.filter(
+    (element) =>
+      element.type.startsWith("pcb_") &&
+      ((element.type === "pcb_component" &&
+        element.pcb_component_id === pcbComponentId) ||
+        ("pcb_component_id" in element &&
+          element.pcb_component_id === pcbComponentId)),
+  )
+  const bounds = getBoundsOfPcbElements(footprintElements)
+  if (!hasFiniteBounds(bounds)) return null
+
+  const childLayer = footprintElements.find(
+    (element) => "layer" in element && typeof element.layer === "string",
+  ) as { layer?: LayerRef } | undefined
+
+  return {
+    component,
+    bounds,
+    layer: component.layer ?? childLayer?.layer ?? "top",
+  }
+}
+
+export const createPcbComponentFocusTransform = ({
+  target,
+  width,
+  height,
+}: {
+  target: PcbComponentFocusTarget
+  width: number
+  height: number
+}): Matrix =>
+  createTransformForBounds({
+    bounds: target.bounds,
+    width,
+    height,
+    padding: PCB_COMPONENT_FOCUS_PADDING_MM,
+    maxScale: PCB_COMPONENT_FOCUS_MAX_SCALE,
+  })
+
+export const shouldHandlePcbComponentFocusRequest = (
+  request: PcbComponentFocusRequest | undefined,
+  lastHandledRequestId: number | null,
+) => Boolean(request && request.requestId !== lastHandledRequestId)
+
+export const shouldResetBoardTransform = ({
+  initialRenderCompleted,
+  boardSizeChanged,
+  hasValidFocusRequest,
+}: {
+  initialRenderCompleted: boolean
+  boardSizeChanged: boolean
+  hasValidFocusRequest: boolean
+}) =>
+  !hasValidFocusRequest &&
+  (!initialRenderCompleted || (initialRenderCompleted && boardSizeChanged))

--- a/src/lib/util/pcb-component-focus.ts
+++ b/src/lib/util/pcb-component-focus.ts
@@ -3,12 +3,12 @@ import type { AnyCircuitElement, LayerRef, PcbComponent } from "circuit-json"
 import type { Matrix } from "transformation-matrix"
 import { createTransformForBounds } from "./error-preview"
 
-export interface PcbComponentFocusRequest {
+export type PcbComponentFocusRequest = {
   pcbComponentId: string
   requestId: number
 }
 
-export interface PcbComponentFocusTarget {
+export type PcbComponentFocusTarget = {
   component: PcbComponent
   bounds: {
     minX: number
@@ -17,6 +17,11 @@ export interface PcbComponentFocusTarget {
     maxY: number
   }
   layer: LayerRef
+}
+
+export type AppliedPcbComponentFocusRequest = {
+  requestId: number
+  circuitJsonKey: string
 }
 
 export const PCB_COMPONENT_FOCUS_PADDING_MM = 1.75
@@ -79,6 +84,22 @@ export const shouldHandlePcbComponentFocusRequest = (
   request: PcbComponentFocusRequest | undefined,
   lastHandledRequestId: number | null,
 ) => Boolean(request && request.requestId !== lastHandledRequestId)
+
+export const isPcbComponentFocusAppliedToCircuit = ({
+  request,
+  appliedRequest,
+  circuitJsonKey,
+}: {
+  request: PcbComponentFocusRequest | undefined
+  appliedRequest: AppliedPcbComponentFocusRequest | null
+  circuitJsonKey: string
+}) =>
+  Boolean(
+    request &&
+      appliedRequest &&
+      request.requestId === appliedRequest.requestId &&
+      circuitJsonKey === appliedRequest.circuitJsonKey,
+  )
 
 export const shouldResetBoardTransform = ({
   initialRenderCompleted,

--- a/tests/lib/pcb-component-focus.test.ts
+++ b/tests/lib/pcb-component-focus.test.ts
@@ -1,0 +1,128 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { applyToPoint } from "transformation-matrix"
+import {
+  createPcbComponentFocusTransform,
+  getPcbComponentFocusTarget,
+  PCB_COMPONENT_FOCUS_MAX_SCALE,
+  shouldHandlePcbComponentFocusRequest,
+  shouldResetBoardTransform,
+} from "../../src/lib/util/pcb-component-focus"
+
+const elements = [
+  {
+    type: "pcb_component",
+    pcb_component_id: "pcb_component_target",
+    source_component_id: "source_component_target",
+    center: { x: 10, y: 5 },
+    width: 2,
+    height: 2,
+    layer: "bottom",
+    rotation: 0,
+  },
+  {
+    type: "pcb_smtpad",
+    pcb_smtpad_id: "left_pad",
+    pcb_component_id: "pcb_component_target",
+    pcb_port_id: "left_port",
+    shape: "rect",
+    x: 6,
+    y: 5,
+    width: 2,
+    height: 4,
+    layer: "bottom",
+  },
+  {
+    type: "pcb_smtpad",
+    pcb_smtpad_id: "right_pad",
+    pcb_component_id: "pcb_component_target",
+    pcb_port_id: "right_port",
+    shape: "rect",
+    x: 14,
+    y: 5,
+    width: 2,
+    height: 4,
+    layer: "bottom",
+  },
+  {
+    type: "pcb_component",
+    pcb_component_id: "pcb_component_unrelated",
+    source_component_id: "source_component_unrelated",
+    center: { x: 100, y: 100 },
+    width: 40,
+    height: 40,
+    layer: "top",
+    rotation: 0,
+  },
+] as AnyCircuitElement[]
+
+test("component focus covers the complete footprint and centers it with padding", () => {
+  const target = getPcbComponentFocusTarget(elements, "pcb_component_target")!
+
+  expect(target.bounds).toEqual({ minX: 5, minY: 3, maxX: 15, maxY: 7 })
+  const transform = createPcbComponentFocusTransform({
+    target,
+    width: 800,
+    height: 600,
+  })
+  expect(applyToPoint(transform, { x: 10, y: 5 })).toEqual({
+    x: 400,
+    y: 300,
+  })
+  expect(Math.abs(transform.a)).toBeLessThanOrEqual(
+    PCB_COMPONENT_FOCUS_MAX_SCALE,
+  )
+
+  const paddedTopLeft = applyToPoint(transform, { x: 3.25, y: 8.75 })
+  const paddedBottomRight = applyToPoint(transform, { x: 16.75, y: 1.25 })
+  expect(paddedTopLeft.x).toBeGreaterThan(0)
+  expect(paddedTopLeft.y).toBeGreaterThan(0)
+  expect(paddedBottomRight.x).toBeLessThan(800)
+  expect(paddedBottomRight.y).toBeLessThan(600)
+})
+
+test("a new request ID retriggers focus for the same component", () => {
+  const firstRequest = {
+    pcbComponentId: "pcb_component_target",
+    requestId: 1,
+  }
+  const secondRequest = { ...firstRequest, requestId: 2 }
+
+  expect(shouldHandlePcbComponentFocusRequest(firstRequest, null)).toBe(true)
+  expect(shouldHandlePcbComponentFocusRequest(firstRequest, 1)).toBe(false)
+  expect(shouldHandlePcbComponentFocusRequest(secondRequest, 1)).toBe(true)
+})
+
+test("invalid component IDs fail safely", () => {
+  expect(getPcbComponentFocusTarget(elements, "missing_component")).toBeNull()
+})
+
+test("component focus suppresses board reset during tab mounting", () => {
+  expect(
+    shouldResetBoardTransform({
+      initialRenderCompleted: false,
+      boardSizeChanged: false,
+      hasValidFocusRequest: true,
+    }),
+  ).toBe(false)
+  expect(
+    shouldResetBoardTransform({
+      initialRenderCompleted: true,
+      boardSizeChanged: true,
+      hasValidFocusRequest: true,
+    }),
+  ).toBe(false)
+  expect(
+    shouldResetBoardTransform({
+      initialRenderCompleted: false,
+      boardSizeChanged: false,
+      hasValidFocusRequest: false,
+    }),
+  ).toBe(true)
+})
+
+test("bottom-layer components request the bottom layer", () => {
+  expect(
+    getPcbComponentFocusTarget(elements, "pcb_component_target")?.layer,
+  ).toBe("bottom")
+})

--- a/tests/lib/pcb-component-focus.test.ts
+++ b/tests/lib/pcb-component-focus.test.ts
@@ -4,6 +4,7 @@ import { applyToPoint } from "transformation-matrix"
 import {
   createPcbComponentFocusTransform,
   getPcbComponentFocusTarget,
+  isPcbComponentFocusAppliedToCircuit,
   PCB_COMPONENT_FOCUS_MAX_SCALE,
   shouldHandlePcbComponentFocusRequest,
   shouldResetBoardTransform,
@@ -81,7 +82,7 @@ test("component focus covers the complete footprint and centers it with padding"
   expect(paddedBottomRight.y).toBeLessThan(600)
 })
 
-test("a new request ID retriggers focus for the same component", () => {
+test("new and interrupted requests trigger component focus", () => {
   const firstRequest = {
     pcbComponentId: "pcb_component_target",
     requestId: 1,
@@ -91,6 +92,47 @@ test("a new request ID retriggers focus for the same component", () => {
   expect(shouldHandlePcbComponentFocusRequest(firstRequest, null)).toBe(true)
   expect(shouldHandlePcbComponentFocusRequest(firstRequest, 1)).toBe(false)
   expect(shouldHandlePcbComponentFocusRequest(secondRequest, 1)).toBe(true)
+
+  const activeRequestIdAfterRendererRemount = null
+  expect(
+    shouldHandlePcbComponentFocusRequest(
+      firstRequest,
+      activeRequestIdAfterRendererRemount,
+    ),
+  ).toBe(true)
+})
+
+test("an applied focus request expires when Circuit JSON changes", () => {
+  const request = {
+    pcbComponentId: "pcb_component_target",
+    requestId: 1,
+  }
+  const appliedRequest = {
+    requestId: 1,
+    circuitJsonKey: "circuit-a",
+  }
+
+  expect(
+    isPcbComponentFocusAppliedToCircuit({
+      request,
+      appliedRequest,
+      circuitJsonKey: "circuit-a",
+    }),
+  ).toBe(true)
+  expect(
+    isPcbComponentFocusAppliedToCircuit({
+      request,
+      appliedRequest,
+      circuitJsonKey: "circuit-b",
+    }),
+  ).toBe(false)
+  expect(
+    isPcbComponentFocusAppliedToCircuit({
+      request: { ...request, requestId: 2 },
+      appliedRequest,
+      circuitJsonKey: "circuit-a",
+    }),
+  ).toBe(false)
 })
 
 test("invalid component IDs fail safely", () => {


### PR DESCRIPTION
## Summary

Adds the PCB-viewer side of schematic-to-PCB component navigation.

- adds the optional controlled `pcbComponentFocusRequest` API
- resolves bounds for the complete component footprint with 1.75 mm padding
- smoothly animates the current transform to a bounded target zoom
- supports repeat requests for the same component via monotonically increasing request IDs
- waits for non-zero viewport dimensions and prevents initial board centering from overwriting focus
- selects the bottom layer for bottom-side components
- safely ignores invalid or stale component IDs
- reuses the existing bounds-transform and animation machinery

## PR chain

**Part 2 of 3 — follows [tscircuit/schematic-viewer#262](https://github.com/tscircuit/schematic-viewer/pull/262).**

1. [tscircuit/schematic-viewer#262](https://github.com/tscircuit/schematic-viewer/pull/262) — navigation callback
2. **This PR:** PCB component focus request
3. [tscircuit/runframe#4668](https://github.com/tscircuit/runframe/pull/4668) — tab and focus integration

The runframe integration should consume released versions from parts 1 and 2.

## Validation

- `bun test` — 47 passed
- formatting check
- TypeScript check
- package build
