### PR TITLE
Fix selected-layer keepout highlighting

### DIFF
--- a/src/components/CanvasPrimitiveRenderer.tsx
+++ b/src/components/CanvasPrimitiveRenderer.tsx
@@ -1,4 +1,4 @@
-import type { AnyCircuitElement, PcbRenderLayer } from "circuit-json"
+import type { AnyCircuitElement, LayerRef, PcbRenderLayer } from "circuit-json"
 import { Drawer } from "lib/Drawer"
 import {
   getCopperLayerRefsFromElements,
@@ -97,11 +97,9 @@ export const CanvasPrimitiveRenderer = ({
     // Draw silkscreen elements using circuit-to-canvas
     if (transform) {
       // Draw plated holes using circuit-to-canvas (pads on copper layers, drills on drill layer)
-      const topCanvas = canvasRefs.current.top
-      const bottomCanvas = canvasRefs.current.bottom
       const copperLayers: Array<{
         canvas?: HTMLCanvasElement
-        layer: string
+        layer: LayerRef
         copperLayer: PcbRenderLayer
       }> = getCopperLayerRefsFromElements(elements).map((layer) => ({
         canvas: canvasRefs.current[layer],
@@ -352,17 +350,12 @@ export const CanvasPrimitiveRenderer = ({
       }
 
       // Draw keepouts using circuit-to-canvas (on copper layers)
-      const keepoutLayers = [
-        { canvas: topCanvas, layer: "top" },
-        { canvas: bottomCanvas, layer: "bottom" },
-      ]
-
-      for (const { canvas, layer } of keepoutLayers) {
+      for (const { canvas, layer } of copperLayers) {
         if (!canvas) continue
         drawPcbKeepoutElementsForLayer({
           canvas,
           elements,
-          layers: [layer],
+          layer,
           realToCanvasMat: transform,
         })
       }

--- a/src/lib/draw-pcb-keepout.ts
+++ b/src/lib/draw-pcb-keepout.ts
@@ -1,31 +1,60 @@
+import type { AnyCircuitElement, LayerRef, PCBKeepout } from "circuit-json"
 import { CircuitToCanvasDrawer } from "circuit-to-canvas"
-import type { AnyCircuitElement } from "circuit-json"
+import color from "color"
 import type { Matrix } from "transformation-matrix"
+import { LAYER_NAME_TO_COLOR } from "./Drawer"
+import { getCopperRenderLayer } from "./copper-layers"
 
-// Color map for keepouts - uses background color for all layers
-
-export function isPcbKeepout(element: AnyCircuitElement) {
+export function isPcbKeepout(
+  element: AnyCircuitElement,
+): element is PCBKeepout {
   return element.type === "pcb_keepout"
+}
+
+export function getPcbKeepoutElementsForLayer({
+  elements,
+  layer,
+}: {
+  elements: AnyCircuitElement[]
+  layer: LayerRef
+}): PCBKeepout[] {
+  return elements
+    .filter(isPcbKeepout)
+    .filter((keepout) => keepout.layers.includes(layer))
+}
+
+export function getPcbKeepoutColorForLayer(layer: LayerRef): string {
+  return color(LAYER_NAME_TO_COLOR[layer]).lighten(0.4).hex()
 }
 
 export function drawPcbKeepoutElementsForLayer({
   canvas,
   elements,
-  layers,
+  layer,
   realToCanvasMat,
 }: {
   canvas: HTMLCanvasElement
   elements: AnyCircuitElement[]
-  layers: string[]
+  layer: LayerRef
   realToCanvasMat: Matrix
 }) {
-  // Filter keepouts to only those on the specified layers
-  const keepoutElements = elements.filter(isPcbKeepout)
+  const keepoutElements = getPcbKeepoutElementsForLayer({ elements, layer })
 
   if (keepoutElements.length === 0) return
 
   const drawer = new CircuitToCanvasDrawer(canvas)
+  const keepoutColor = getPcbKeepoutColorForLayer(layer)
+  drawer.configure({
+    colorOverrides: {
+      keepout: {
+        top: keepoutColor,
+        bottom: keepoutColor,
+      },
+    },
+  })
   drawer.realToCanvasMat = realToCanvasMat
 
-  drawer.drawElements(keepoutElements, { layers: [] })
+  drawer.drawElements(keepoutElements, {
+    layers: [getCopperRenderLayer(layer)],
+  })
 }

--- a/tests/lib/draw-pcb-keepout.test.ts
+++ b/tests/lib/draw-pcb-keepout.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import {
+  getPcbKeepoutColorForLayer,
+  getPcbKeepoutElementsForLayer,
+} from "../../src/lib/draw-pcb-keepout"
+
+const elements = [
+  {
+    type: "pcb_keepout",
+    pcb_keepout_id: "top_keepout",
+    shape: "rect",
+    center: { x: 0, y: 0 },
+    width: 1,
+    height: 1,
+    layers: ["top"],
+  },
+  {
+    type: "pcb_keepout",
+    pcb_keepout_id: "inner_keepout",
+    shape: "circle",
+    center: { x: 2, y: 0 },
+    radius: 1,
+    layers: ["inner1"],
+  },
+  {
+    type: "pcb_keepout",
+    pcb_keepout_id: "shared_keepout",
+    shape: "rect",
+    center: { x: 4, y: 0 },
+    width: 1,
+    height: 1,
+    layers: ["top", "inner1"],
+  },
+] as AnyCircuitElement[]
+
+describe("PCB keepout layer rendering", () => {
+  it("only returns keepouts assigned to the requested copper layer", () => {
+    expect(
+      getPcbKeepoutElementsForLayer({ elements, layer: "top" }).map(
+        (keepout) => keepout.pcb_keepout_id,
+      ),
+    ).toEqual(["top_keepout", "shared_keepout"])
+
+    expect(
+      getPcbKeepoutElementsForLayer({ elements, layer: "inner1" }).map(
+        (keepout) => keepout.pcb_keepout_id,
+      ),
+    ).toEqual(["inner_keepout", "shared_keepout"])
+
+    expect(
+      getPcbKeepoutElementsForLayer({ elements, layer: "bottom" }),
+    ).toEqual([])
+  })
+
+  it("uses a distinct highlight color for each copper layer", () => {
+    expect(getPcbKeepoutColorForLayer("top")).not.toBe(
+      getPcbKeepoutColorForLayer("inner1"),
+    )
+    expect(getPcbKeepoutColorForLayer("inner1")).not.toBe(
+      getPcbKeepoutColorForLayer("bottom"),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- filter PCB keepouts to their declared copper layers before rendering
- render keepouts on every copper canvas, including inner layers
- tint keepout hatching with the owning layer color so the selected layer stands out through the viewer's existing layer ordering and opacity
- add regression coverage for single-layer and shared keepouts

## Testing

- `bun test`
- `bunx tsc --noEmit`
- `bun run build`
- `bunx biome check src/lib/draw-pcb-keepout.ts src/components/CanvasPrimitiveRenderer.tsx tests/lib/draw-pcb-keepout.test.ts`