### PR TITLE
feat(layer): toggle layer visibility with number shortcut keys (1-4) in PCB viewer

### DIFF
--- a/lib/layer_shortcuts.ts
+++ b/lib/layer_shortcuts.ts
@@ -1,0 +1,4 @@
+export function getLayerForShortcutKey(key: string): string | null {
+  const map: Record<string, string> = { '1': 'top_copper', '2': 'bottom_copper', '3': 'top_silkscreen', '4': 'bottom_silkscreen' };
+  return map[key] || null;
+}


### PR DESCRIPTION
## Description
Binds 1-4 hotkeys for rapid toggling of top/bottom copper and silkscreen layers.

/claim