### PR TITLE
Add PCB debug object view toggle

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@tscircuit/alphabet": "^0.0.25",
         "@tscircuit/math-utils": "^0.0.36",
         "@vitejs/plugin-react": "^5.0.2",
-        "circuit-json": "^0.0.469",
+        "circuit-json": "^0.0.473",
         "circuit-to-canvas": "0.0.124",
         "color": "^4.2.3",
         "react-supergrid": "^1.0.10",
@@ -642,7 +642,7 @@
 
     "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
-    "circuit-json": ["circuit-json@0.0.469", "", { "peerDependencies": { "format-si-unit": "*" } }, "sha512-ThMs+rYs7KtQUj/s19zyHN50I4MJIZRQfpEyaxd00YBu0f5nuF6oOTPulJpUALxVBZX42u/ooJS+qyU+7o0l/w=="],
+    "circuit-json": ["circuit-json@0.0.473", "", { "peerDependencies": { "format-si-unit": "*" } }, "sha512-FtY6N7+iuhE/xUwqaTDk7wXHAmtcK9t4uyzMyYNLxhQhmQjatrcdmq8tRELCjWHcMyfA1cqBCFit8APpTLz5mg=="],
 
     "circuit-json-to-bpc": ["circuit-json-to-bpc@0.0.13", "", { "peerDependencies": { "bpc-graph": "*", "circuit-json": "*", "typescript": "^5" } }, "sha512-3wSMtPa6tJkiBQN4tsm7f0Mb7Wp90X2c8dNbULoDVE4mGGoFqP1DXqBlyvvZZl+4SjqznzQQ0EioLe2SCQTOcg=="],
 
@@ -2367,6 +2367,8 @@
     "tinyglobby/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
 
     "tscircuit/@tscircuit/circuit-json-util": ["@tscircuit/circuit-json-util@0.0.106", "", { "dependencies": { "parsel-js": "^1.1.2" }, "peerDependencies": { "circuit-json": "*", "transformation-matrix": "*", "zod": "3" } }, "sha512-7HxREkrIiC+EcuJYU4i5o9UbTRhgoeTOY03zCHeGhNUhUbUlrDdIciraI1Yn+qb+/ot5+QbhkrqZMTAV8lmpmw=="],
+
+    "tscircuit/circuit-json": ["circuit-json@0.0.469", "", { "peerDependencies": { "format-si-unit": "*" } }, "sha512-ThMs+rYs7KtQUj/s19zyHN50I4MJIZRQfpEyaxd00YBu0f5nuF6oOTPulJpUALxVBZX42u/ooJS+qyU+7o0l/w=="],
 
     "tscircuit/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@tscircuit/alphabet": "^0.0.25",
     "@tscircuit/math-utils": "^0.0.36",
     "@vitejs/plugin-react": "^5.0.2",
-    "circuit-json": "^0.0.469",
+    "circuit-json": "^0.0.473",
     "circuit-to-canvas": "0.0.124",
     "color": "^4.2.3",
     "react-supergrid": "^1.0.10",

--- a/src/components/CanvasPrimitiveRenderer.tsx
+++ b/src/components/CanvasPrimitiveRenderer.tsx
@@ -13,6 +13,7 @@ import { drawPcbHoleElementsForLayer } from "lib/draw-hole"
 import { drawPcbBoardElements } from "lib/draw-pcb-board"
 import { drawPcbCopperTextElementsForLayer } from "lib/draw-pcb-copper-text"
 import { drawPcbCutoutElementsForLayer } from "lib/draw-pcb-cutout"
+import { drawPcbDebugObjects } from "lib/draw-pcb-debug-object"
 import { drawPcbKeepoutElementsForLayer } from "lib/draw-pcb-keepout"
 import { drawPcbNoteElementsForLayer } from "lib/draw-pcb-note"
 import { drawPcbPanelElements } from "lib/draw-pcb-panel"
@@ -55,6 +56,9 @@ export const CanvasPrimitiveRenderer = ({
     (s) => s.is_showing_fabrication_notes,
   )
   const isShowingPcbNotes = useGlobalStore((s) => s.is_showing_pcb_notes)
+  const isShowingDebugObjects = useGlobalStore(
+    (s) => s.is_showing_debug_objects,
+  )
   const isShowingCourtyards = useGlobalStore((s) => s.is_showing_courtyards)
   const isShowingSilkscreen = useGlobalStore((s) => s.is_showing_silkscreen)
 
@@ -359,6 +363,17 @@ export const CanvasPrimitiveRenderer = ({
           realToCanvasMat: transform,
         })
       }
+
+      if (isShowingDebugObjects) {
+        const debugObjectsCanvas = canvasRefs.current.debug_objects
+        if (debugObjectsCanvas) {
+          drawPcbDebugObjects({
+            canvas: debugObjectsCanvas,
+            elements,
+            realToCanvasMat: transform,
+          })
+        }
+      }
     }
 
     drawer.orderAndFadeLayers()
@@ -371,6 +386,7 @@ export const CanvasPrimitiveRenderer = ({
     isShowingSolderMask,
     isShowingFabricationNotes,
     isShowingPcbNotes,
+    isShowingDebugObjects,
     isShowingCourtyards,
     isShowingSilkscreen,
   ])

--- a/src/components/ToolbarOverlay.tsx
+++ b/src/components/ToolbarOverlay.tsx
@@ -156,6 +156,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     setIsShowingSilkscreen,
     setIsShowingFabricationNotes,
     setIsShowingPcbNotes,
+    setIsShowingDebugObjects,
     setPcbGroupViewMode,
     setHoveredErrorId,
     setFocusedErrorId,
@@ -178,6 +179,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
       is_showing_silkscreen: s.is_showing_silkscreen,
       is_showing_fabrication_notes: s.is_showing_fabrication_notes,
       is_showing_pcb_notes: s.is_showing_pcb_notes,
+      is_showing_debug_objects: s.is_showing_debug_objects,
       pcb_group_view_mode: s.pcb_group_view_mode,
     },
     setIsShowingRatsNest: s.setIsShowingRatsNest,
@@ -193,6 +195,7 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
     setIsShowingSilkscreen: s.setIsShowingSilkscreen,
     setIsShowingFabricationNotes: s.setIsShowingFabricationNotes,
     setIsShowingPcbNotes: s.setIsShowingPcbNotes,
+    setIsShowingDebugObjects: s.setIsShowingDebugObjects,
     setPcbGroupViewMode: s.setPcbGroupViewMode,
     setHoveredErrorId: s.setHoveredErrorId,
     setFocusedErrorId: s.setFocusedErrorId,
@@ -603,6 +606,15 @@ export const ToolbarOverlay = ({ children, elements }: Props) => {
                   checked={viewSettings.is_showing_pcb_notes}
                   onClick={() => {
                     setIsShowingPcbNotes(!viewSettings.is_showing_pcb_notes)
+                  }}
+                />
+                <CheckboxMenuItem
+                  label="Show Debug Objects"
+                  checked={viewSettings.is_showing_debug_objects}
+                  onClick={() => {
+                    setIsShowingDebugObjects(
+                      !viewSettings.is_showing_debug_objects,
+                    )
                   }}
                 />
                 <CheckboxMenuItem

--- a/src/global-store.ts
+++ b/src/global-store.ts
@@ -36,6 +36,7 @@ export interface State {
   is_showing_silkscreen: boolean
   is_showing_fabrication_notes: boolean
   is_showing_pcb_notes: boolean
+  is_showing_debug_objects: boolean
   pcb_group_view_mode: "all" | "named_only"
 
   hovered_error_id: string | null
@@ -58,6 +59,7 @@ export interface State {
   setIsShowingSilkscreen: (is_showing: boolean) => void
   setIsShowingFabricationNotes: (is_showing: boolean) => void
   setIsShowingPcbNotes: (is_showing: boolean) => void
+  setIsShowingDebugObjects: (is_showing: boolean) => void
   setPcbGroupViewMode: (mode: "all" | "named_only") => void
   setHoveredErrorId: (errorId: string | null) => void
   setFocusedErrorId: (errorId: string | null) => void
@@ -122,6 +124,10 @@ export const createStore = (
         is_showing_pcb_notes: getStoredBoolean(
           STORAGE_KEYS.IS_SHOWING_PCB_NOTES,
           true,
+        ),
+        is_showing_debug_objects: getStoredBoolean(
+          STORAGE_KEYS.IS_SHOWING_DEBUG_OBJECTS,
+          process.env.NODE_ENV !== "production",
         ),
         pcb_group_view_mode: disablePcbGroups
           ? "all"
@@ -193,6 +199,10 @@ export const createStore = (
         setIsShowingPcbNotes: (is_showing) => {
           setStoredBoolean(STORAGE_KEYS.IS_SHOWING_PCB_NOTES, is_showing)
           set({ is_showing_pcb_notes: is_showing })
+        },
+        setIsShowingDebugObjects: (is_showing) => {
+          setStoredBoolean(STORAGE_KEYS.IS_SHOWING_DEBUG_OBJECTS, is_showing)
+          set({ is_showing_debug_objects: is_showing })
         },
         setPcbGroupViewMode: (mode) => {
           if (disablePcbGroups) return

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -9,6 +9,7 @@ export const STORAGE_KEYS = {
   IS_SHOWING_SOLDER_MASK: "pcb_viewer_is_showing_solder_mask",
   IS_SHOWING_FABRICATION_NOTES: "pcb_viewer_is_showing_fabrication_notes",
   IS_SHOWING_PCB_NOTES: "pcb_viewer_is_showing_pcb_notes",
+  IS_SHOWING_DEBUG_OBJECTS: "pcb_viewer_is_showing_debug_objects",
   IS_SHOWING_SILKSCREEN: "pcb_viewer_is_showing_silkscreen",
 } as const
 

--- a/src/lib/copper-layers.ts
+++ b/src/lib/copper-layers.ts
@@ -58,5 +58,6 @@ export const getOrderedCanvasLayers = (
     "top_courtyard",
     "bottom_courtyard",
     "other",
+    "debug_objects",
   ]
 }

--- a/src/lib/draw-pcb-debug-object.ts
+++ b/src/lib/draw-pcb-debug-object.ts
@@ -15,6 +15,10 @@ export function drawPcbDebugObjects({
   drawer.realToCanvasMat = realToCanvasMat
   drawer.drawElements(
     elements.filter((element) => element.type === "pcb_debug_object"),
-    { layers: [], showDebugObjects: true },
+    // Remove the cast when the circuit-to-canvas release containing
+    // showDebugObjects is installed.
+    { layers: [], showDebugObjects: true } as Parameters<
+      typeof drawer.drawElements
+    >[1],
   )
 }

--- a/src/lib/draw-pcb-debug-object.ts
+++ b/src/lib/draw-pcb-debug-object.ts
@@ -1,0 +1,20 @@
+import type { AnyCircuitElement } from "circuit-json"
+import { CircuitToCanvasDrawer } from "circuit-to-canvas"
+import type { Matrix } from "transformation-matrix"
+
+export function drawPcbDebugObjects({
+  canvas,
+  elements,
+  realToCanvasMat,
+}: {
+  canvas: HTMLCanvasElement
+  elements: AnyCircuitElement[]
+  realToCanvasMat: Matrix
+}) {
+  const drawer = new CircuitToCanvasDrawer(canvas)
+  drawer.realToCanvasMat = realToCanvasMat
+  drawer.drawElements(
+    elements.filter((element) => element.type === "pcb_debug_object"),
+    { layers: [], showDebugObjects: true },
+  )
+}

--- a/tests/global-store.test.ts
+++ b/tests/global-store.test.ts
@@ -20,3 +20,13 @@ test("DRC warnings are shown by default and can be hidden", () => {
 
   expect(store.getState().is_showing_drc_warnings).toBe(false)
 })
+
+test("PCB debug objects are shown by default in development and can be hidden", () => {
+  const store = createStore()
+
+  expect(store.getState().is_showing_debug_objects).toBe(true)
+
+  store.getState().setIsShowingDebugObjects(false)
+
+  expect(store.getState().is_showing_debug_objects).toBe(false)
+})


### PR DESCRIPTION
## Summary

- render `pcb_debug_object` elements on a dedicated top canvas layer
- add a persisted View menu toggle
- default debug objects to visible outside production builds
- upgrade circuit-json for the new element type

## Dependency

Stacked on tscircuit/circuit-to-canvas#283. The released circuit-to-canvas version will be bumped here after that PR merges and publishes.

## Validation

- `bun test` (45 pass)
- `bun run build`
- `git diff --check`
