### PR TITLE
fix: cleanly resolve legacy disableAutoFocus fixture (#163)

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }


### PR DESCRIPTION
/claim #163

This PR cleanly finishes the work for #163. 

The \disableAutoFocus\ prop was already successfully removed from the main \<PCBViewer />\ component in a previous commit. The only remaining issue was the legacy fixture \DisabledAutoFocus\ which was still named incorrectly and failed to explicitly pass \ocusOnHover={false}\ to actually test the disabled behavior. 

This PR:
1. Renames the fixture from \DisabledAutoFocus\ to \FocusOnHoverDisabled\.
2. Explicitly sets \ocusOnHover={false}\ inside the fixture so it continues testing the disabled state appropriately. 

No core component logic is modified as the primary prop removal was already completed.