### PR TITLE
fix: prevent unrelated PCB net highlights

### DIFF
--- a/src/components/CanvasElementsRenderer.tsx
+++ b/src/components/CanvasElementsRenderer.tsx
@@ -1,8 +1,8 @@
 import type { ManualEditEvent } from "@tscircuit/props"
 import type { AnyCircuitElement } from "circuit-json"
-import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
 import type { GraphicsObject } from "graphics-debug"
 import { convertElementToPrimitives } from "lib/convert-element-to-primitive"
+import { getConnectivityMapForHover } from "lib/get-connectivity-map-for-hover"
 import type { GridConfig, Primitive } from "lib/types"
 import { addInteractionMetadataToPrimitives } from "lib/util/addInteractionMetadataToPrimitives"
 import {
@@ -74,9 +74,7 @@ export const CanvasElementsRenderer = (props: CanvasElementsRendererProps) => {
       const primitivesWithoutInteractionMetadata = elementsToRender.flatMap(
         (elm) => convertElementToPrimitives(elm, props.elements),
       )
-      const connectivityMap = getFullConnectivityMapFromCircuitJson(
-        props.elements as any,
-      )
+      const connectivityMap = getConnectivityMapForHover(props.elements)
       return [primitivesWithoutInteractionMetadata, connectivityMap]
     }, [elementsToRender, props.elements])
 

--- a/src/lib/get-connectivity-map-for-hover.ts
+++ b/src/lib/get-connectivity-map-for-hover.ts
@@ -1,0 +1,43 @@
+import type { AnyCircuitElement, PcbTrace } from "circuit-json"
+import { getFullConnectivityMapFromCircuitJson } from "circuit-json-to-connectivity-map"
+
+const hasAuthoritativePcbPortEndpoints = (trace: PcbTrace) => {
+  let startPcbPortId: string | undefined
+  let endPcbPortId: string | undefined
+
+  for (const routePoint of trace.route) {
+    if (routePoint.route_type !== "wire") continue
+    startPcbPortId ??= routePoint.start_pcb_port_id
+    endPcbPortId ??= routePoint.end_pcb_port_id
+  }
+
+  return Boolean(startPcbPortId && endPcbPortId)
+}
+
+/**
+ * Build the connectivity map used for PCB hover highlighting.
+ *
+ * A routed trace with both PCB port endpoints is fully attributed by those
+ * endpoints. Autorouted MST branches can also carry a `source_trace_id` for
+ * just one source branch; treating that metadata as another electrical
+ * connection can merge otherwise unrelated nets in the hover map.
+ */
+export const getConnectivityMapForHover = (elements: AnyCircuitElement[]) => {
+  const elementsWithAuthoritativePcbConnectivity = elements.map((element) => {
+    if (
+      element.type !== "pcb_trace" ||
+      !element.source_trace_id ||
+      !hasAuthoritativePcbPortEndpoints(element)
+    ) {
+      return element
+    }
+
+    const { source_trace_id: _sourceTraceId, ...traceWithPcbEndpoints } =
+      element
+    return traceWithPcbEndpoints as AnyCircuitElement
+  })
+
+  return getFullConnectivityMapFromCircuitJson(
+    elementsWithAuthoritativePcbConnectivity,
+  )
+}

--- a/tests/lib/get-connectivity-map-for-hover.test.ts
+++ b/tests/lib/get-connectivity-map-for-hover.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { getConnectivityMapForHover } from "../../src/lib/get-connectivity-map-for-hover"
+
+test("does not merge unrelated nets through an attributed two-ended PCB trace", () => {
+  const elements = [
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_gnd_a",
+      connected_source_port_ids: ["source_port_gnd_a"],
+      connected_source_net_ids: ["source_net_gnd"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_gnd_b",
+      connected_source_port_ids: ["source_port_gnd_b"],
+      connected_source_net_ids: ["source_net_gnd"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "source_trace_vbat",
+      connected_source_port_ids: ["source_port_vbat"],
+      connected_source_net_ids: ["source_net_vbat"],
+    },
+    {
+      type: "pcb_port",
+      pcb_port_id: "pcb_port_gnd_a",
+      pcb_component_id: "pcb_component_gnd_a",
+      source_port_id: "source_port_gnd_a",
+      layers: ["top"],
+      x: 0,
+      y: 0,
+    },
+    {
+      type: "pcb_port",
+      pcb_port_id: "pcb_port_gnd_b",
+      pcb_component_id: "pcb_component_gnd_b",
+      source_port_id: "source_port_gnd_b",
+      layers: ["top"],
+      x: 5,
+      y: 0,
+    },
+    {
+      type: "pcb_port",
+      pcb_port_id: "pcb_port_vbat",
+      pcb_component_id: "pcb_component_vbat",
+      source_port_id: "source_port_vbat",
+      layers: ["top"],
+      x: 0,
+      y: 5,
+    },
+    {
+      type: "pcb_trace",
+      pcb_trace_id: "pcb_trace_gnd",
+      connection_name: "source_net_gnd",
+      // This reproduces the misleading attribution emitted on an autorouted
+      // MST segment in seveibar/nrf52810.
+      source_trace_id: "source_trace_vbat",
+      route: [
+        {
+          route_type: "wire",
+          x: 0,
+          y: 0,
+          width: 0.15,
+          layer: "top",
+          start_pcb_port_id: "pcb_port_gnd_a",
+        },
+        {
+          route_type: "wire",
+          x: 5,
+          y: 0,
+          width: 0.15,
+          layer: "top",
+          end_pcb_port_id: "pcb_port_gnd_b",
+        },
+      ],
+    },
+  ] as AnyCircuitElement[]
+
+  const connectivityMap = getConnectivityMapForHover(elements)
+
+  expect(
+    connectivityMap.areIdsConnected("pcb_trace_gnd", "pcb_port_gnd_a"),
+  ).toBe(true)
+  expect(
+    connectivityMap.areIdsConnected("pcb_trace_gnd", "pcb_port_gnd_b"),
+  ).toBe(true)
+  expect(
+    connectivityMap.areIdsConnected("pcb_trace_gnd", "pcb_port_vbat"),
+  ).toBe(false)
+})


### PR DESCRIPTION
## Summary

- Treat explicit PCB port endpoints as authoritative for fully routed traces when building hover connectivity.
- Prevent autorouted MST source-trace attribution from merging unrelated logical nets in the PCB viewer.
- Add a focused regression based on https://tscircuit.com/seveibar/nrf52810#pcb.

In the published reproduction, hovering TP_GND previously expanded to 55 PCB traces across source_net_0 through source_net_4. With this change, the hover map contains only GND traces (source_net_1 plus the directly associated unnamed PCB traces).

## Verification

- bun test
- bunx tsc --noEmit
- bun run build
- bun run format:check