### PR TITLE
docs: fix component usage example, props table, and development guidelines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,8 +5,8 @@
 - Format code: `npm run format` (Biome formatter)
 - Check formatting: `npm run format:check`
 - Type check: `npx tsc --noEmit`
-- Run Storybook: `npm run storybook` or `npm start`
-- Build Storybook: `npm run build-storybook`
+- Run Cosmos (fixtures / dev): `npm start` or `npm run cosmos`
+- Export Cosmos fixtures: `npm run cosmos-export`
 - Build and publish to yalc: `npm run yalc`
 
 ## Code Style Guidelines

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![npm version](https://badge.fury.io/js/@tscircuit%2Fpcb-viewer.svg)](https://badge.fury.io/js/@tscircuit%2Fpcb-viewer)
 
-[Examples](https://pcb-viewer.vercel.app/) &middot; [TSCircuit](https://tscircuit.com) &middot; [Open in CodeSandbox](https://codesandbox.io/p/github/tscircuit/pcb-viewer)
+[Examples](https://pcb-viewer.vercel.app/) &middot; [TSCircuit](https://tscircuit.com)
 
 Render Printed Circuit Boards w/ React
 
@@ -16,44 +16,62 @@ If you want to render to an image, check out [circuit-to-png](https://github.com
 npm install @tscircuit/pcb-viewer
 ```
 
-There are two main ways to use the PCBViewer:
+There are two primary ways to provide circuit data to `PCBViewer`:
 
-### 1. Using Circuit Components
+### 1. Using Circuit Components with `@tscircuit/core`
 
-This approach allows you to declaratively define your circuit using React components:
+To declaratively define your circuit using React components, use `@tscircuit/core` to build the circuit and extract Circuit JSON:
+
+```bash
+npm install @tscircuit/core
+```
 
 ```tsx
-import React from "react"
+import React, { useMemo } from "react"
+import { Circuit } from "@tscircuit/core"
 import { PCBViewer } from "@tscircuit/pcb-viewer"
 
 export default () => {
+  const circuitJson = useMemo(() => {
+    const circuit = new Circuit()
+    circuit.add(
+      <board width="20mm" height="20mm">
+        <resistor footprint="0805" resistance="10k" name="R1" />
+        <capacitor footprint="0603" capacitance="100nF" name="C1" />
+      </board>,
+    )
+    return circuit.getCircuitJson()
+  }, [])
+
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer>
-        <resistor footprint="0805" resistance="10k" />
-        <capacitor footprint="0603" capacitance="100nF" />
-      </PCBViewer>
+      <PCBViewer circuitJson={circuitJson} />
     </div>
   )
 }
 ```
 
-### 2. Using Circuit JSON
+### 2. Using Circuit JSON Directly
 
-If you already have circuit JSON data, you can pass it directly:
+If you already have Circuit JSON elements (from `@tscircuit/core`, an API, or a saved file), pass them directly via `circuitJson`:
 
 ```tsx
 import React from "react"
 import { PCBViewer } from "@tscircuit/pcb-viewer"
+import type { AnyCircuitElement } from "circuit-json"
 
-const circuitJson = [
+const circuitJson: AnyCircuitElement[] = [
   {
     type: "pcb_component",
     pcb_component_id: "R1",
     center: { x: 0, y: 0 },
-    // ... other component properties
+    width: 2,
+    height: 1.25,
+    layer: "top",
+    rotation: 0,
+    source_component_id: "source_R1",
   },
-  // ... more elements
+  // ... other circuit elements
 ]
 
 export default () => {
@@ -67,22 +85,29 @@ export default () => {
 
 ### Props
 
-The PCBViewer component accepts these props:
+The `PCBViewer` component accepts the following props:
 
-- `children`: Circuit components to render
-- `circuitJson`: Circuit JSON elements array (alternative to children)
-- `height`: Height of viewer in pixels (default: 600)
-- `allowEditing`: Enable/disable editing capabilities (default: true)
-- `editEvents`: Array of edit events to apply
-- `onEditEventsChanged`: Callback when edit events change
-- `onBoundsSelected`: Callback when the Bounds tool completes a rectangle selection. Receives `{ minX, minY, maxX, maxY }`.
-- `initialState`: Initial state for the viewer
+| Prop | Type | Default | Description |
+|---|---|---|---|
+| `circuitJson` | `AnyCircuitElement[]` | `undefined` | Array of Circuit JSON elements representing the PCB layout, traces, pads, holes, and components. |
+| `height` | `number` | `600` | Height of the viewer canvas container in pixels. |
+| `allowEditing` | `boolean` | `true` | Enables or disables component placement editing. |
+| `editEvents` | `ManualEditEvent[]` | `[]` | Controlled array of manual edit events to apply to component placements. |
+| `onEditEventsChanged` | `(editEvents: ManualEditEvent[]) => void` | `undefined` | Callback fired when component placement edit events are created or updated. |
+| `onBoundsSelected` | `(bounds: BoundsSelection) => void` | `undefined` | Callback fired when the Bounds tool finishes selecting a bounding rectangle (`{ minX, minY, maxX, maxY }`). |
+| `initialState` | `Partial<StateProps>` | `undefined` | Initial view state options (e.g. toggles for solder mask, copper pours, PCB notes, or layer visibility). |
+| `focusOnHover` | `boolean` | `false` | Enables automatic canvas focus on mouse hover for immediate keyboard and mouse interactions. |
+| `clickToInteractEnabled` | `boolean` | `false` | When enabled, displays a "Click to Interact" / "Touch to Interact" overlay preventing page scroll capture until clicked. |
+| `debugGraphics` | `GraphicsObject \| null` | `null` | Optional debug graphics overlay (e.g. autorouting lines, routing obstacles, and debug points). |
+| `disablePcbGroups` | `boolean` | `false` | Disables rendering and selection overlays for PCB group containers. |
 
 ### Features
 
-- Interactive PCB viewing with pan and zoom
-- Multiple layer support (top, bottom, inner layers)
-- Component placement editing
-- Trace routing
-- DRC (Design Rule Check) visualization
-- Measurement tools
+- **Interactive Canvas**: High-performance WebGL rendering via PixiJS with smooth panning and zooming.
+- **Multi-Layer Rendering**: Top/bottom copper, inner layers, silkscreen text/shapes, solder mask, and drill holes.
+- **Net Connectivity Inspection**: Hover over any trace, pad, or net to highlight connected traces across layers.
+- **Component Placement Editing**: Interactive footprint dragging and rotation with edit event tracking (`onEditEventsChanged`).
+- **DRC & Warning Overlays**: Real-time Design Rule Check (DRC) visual indicators and connector orientation warnings.
+- **Measurement & Bounding Tools**: Interactive dimension line tools and rectangle bounds selection (`onBoundsSelected`).
+- **PCB Groups**: Hierarchy visualization and group anchor offset indicators.
+- **Autorouter Debugging**: Visualize autorouting graph nodes, obstacles, and debug paths via `debugGraphics`.


### PR DESCRIPTION
## Summary

- Correct `README.md` usage example to demonstrate compiling circuit components with `@tscircuit/core` (`new Circuit()`) to produce `circuitJson`, eliminating broken `<PCBViewer><resistor ... /></PCBViewer>` usage that threw TypeScript errors and failed to render.
- Replace the unformatted props list with a complete, typed markdown table: remove the non-existent `children` prop and document `focusOnHover`, `clickToInteractEnabled`, `debugGraphics`, and `disablePcbGroups`.
- Update the features list to accurately reflect current viewer capabilities (net connectivity inspection, PCB groups, autorouter debug overlays) and remove deprecated trace routing (which was removed in #953).
- Remove broken CodeSandbox link (addressing maintainer Matthew Campbell's PR #934).
- Update `CLAUDE.md` to reference React Cosmos (`npm start` / `npm run cosmos`) instead of non-existent `npm run storybook` scripts.

## Why

New users and developers integrating `@tscircuit/pcb-viewer` encounter immediate friction when following the README:
1. `PCBViewer` has no `children` prop and cannot directly render raw circuit JSX primitives without `@tscircuit/core`.
2. Several production props (`focusOnHover`, `clickToInteractEnabled`, `debugGraphics`, `disablePcbGroups`) were missing from the props documentation.
3. The feature list referenced trace routing which has been completely removed as dead code.
4. `CLAUDE.md` directed contributors to run Storybook, which was migrated away from in favor of React Cosmos.

## Verification

- Verified all props against `src/PCBViewer.tsx` (`type Props`).
- Verified script names against `package.json` (`cosmos`, `cosmos-export`).
- Verified markdown rendering and table formatting.

Closes #978
