### PR TITLE
fix: replace legacy DisabledAutoFocus fixture with FocusOnHoverDisabled using focusOnHover={false}

### DIFF
--- a/src/examples/2025/board.fixture.tsx
+++ b/src/examples/2025/board.fixture.tsx
@@ -112,7 +112,7 @@ export const AtariBoard = () => {
   )
 }
 
-export const DisabledAutoFocus = () => {
+export const FocusOnHoverDisabled = () => {
   const circuit = new Circuit()
 
   circuit.add(<board pcbX={0} pcbY={0} width="50mm" height="50mm" />)
@@ -121,7 +121,7 @@ export const DisabledAutoFocus = () => {
 
   return (
     <div style={{ backgroundColor: "black" }}>
-      <PCBViewer circuitJson={soup as any} />
+      <PCBViewer circuitJson={soup as any} focusOnHover={false} />
     </div>
   )
 }
@@ -131,4 +131,5 @@ export default {
   TriangleBoard,
   OctagonBoard,
   AtariBoard,
+  FocusOnHoverDisabled,
 }


### PR DESCRIPTION
fix: replace legacy DisabledAutoFocus fixture with FocusOnHoverDisabled

The `DisabledAutoFocus` fixture in `src/examples/2025/board.fixture.tsx` was a leftover from before the `focusOnHover` prop existed. It didn't actually disable hover-focus (it never passed any prop), so it exercised nothing beyond `BasicRectangleBoard`.

This replaces it with a `FocusOnHoverDisabled` fixture that explicitly passes `focusOnHover={false}`, and exports it so it appears in the fixture browser.

/claim #163